### PR TITLE
Modifying id -> clusterId as API filter expects key to be clusterId

### DIFF
--- a/aws/files/userdata_agent
+++ b/aws/files/userdata_agent
@@ -88,7 +88,7 @@ while true; do
     $curlimage \
       -sLk \
       -H "Authorization: Bearer $LOGINTOKEN" \
-      "https://$rancher_server_ip/v3/clusterregistrationtoken?id=$CLUSTERID" | docker run --rm -i $jqimage -r '.data[].nodeCommand' | head -1)
+      "https://$rancher_server_ip/v3/clusterregistrationtoken?clusterId=$CLUSTERID" | docker run --rm -i $jqimage -r '.data[].nodeCommand' | head -1)
 
   if [ -n "$AGENTCMD" ]; then
     break

--- a/do/files/userdata_agent
+++ b/do/files/userdata_agent
@@ -88,7 +88,7 @@ while true; do
     $curlimage \
       -sLk \
       -H "Authorization: Bearer $LOGINTOKEN" \
-      "https://$rancher_server_ip/v3/clusterregistrationtoken?id=$CLUSTERID" | docker run --rm -i $jqimage -r '.data[].nodeCommand' | head -1)
+      "https://$rancher_server_ip/v3/clusterregistrationtoken?clusterId=$CLUSTERID" | docker run --rm -i $jqimage -r '.data[].nodeCommand' | head -1)
 
   if [ -n "$AGENTCMD" ]; then
     break


### PR DESCRIPTION
The Rancher 2.0 v3 API filter for `clusterregistrationtoken` expects a `clusterId` key rather than simply `id`. In the event that you have more than one cluster (say, if you were to modify the userdata_server file) your downstream nodes would not be able to bootstrap themselves as they would receive multiple cluster registration tokens.

@chrisurwin @superseb Can you help me verify that this change still works? I have tested in AWS/DO but a second/third set of eyes is always awesome.