### PR TITLE
The run terraform init was missing from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This terraform setup will:
 
 - Clone this repository and go into the DO subfolder
 - Move the file `terraform.tfvars.example` to `terraform.tfvars` and edit (see inline explanation)
+- Run `terraform init`
 - Run `terraform apply`
 
 When provisioning has finished you will be given the url to connect to the Rancher Server
@@ -71,6 +72,7 @@ This terraform setup will:
 
 - Clone this repository and go into the aws subfolder
 - Move the file `terraform.tfvars.example` to `terraform.tfvars` and edit (see inline explanation)
+- Run `terraform init`
 - Run `terraform apply`
 
 When provisioning has finished you will be given the url to connect to the Rancher Server


### PR DESCRIPTION
… , but is correct at https://rancher.com/docs/rancher/v2.x/en/quick-start-guide/deployment/digital-ocean-qs/ and https://rancher.com/docs/rancher/v2.x/en/quick-start-guide/deployment/amazon-aws-qs/ Without init, apply fails with:

```
$ terraform apply
Plugin reinitialization required. Please run "terraform init".
Reason: Could not satisfy plugin requirements.
...
```