### PR TITLE
Added cluster_name variable to Terraform example.

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -12,6 +12,8 @@ prefix = "myname"
 admin_password = "admin"
 # rancher/rancher image tag to use
 rancher_version = "latest"
+# Kubernetes cluster name
+cluster_name = "quickstart"
 # Count of agent nodes with role all
 count_agent_all_nodes = "1"
 # Count of agent nodes with role etcd


### PR DESCRIPTION
Cluster_name is referenced in the README, but was not exposed as a variable in the terraform.tfvars.example file.