### PR TITLE
Added Scaleway as a quickstart alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ To remove the VM's that have been deployed run `terraform destroy --force`
 
 **Please be aware that you will be responsible for the usage charges with Digital Ocean**
 
+## Scaleway quick start
+
+The Scaleway folder contains terraform code to stand up a single Rancher server instance with a 3 node cluster attached to it.
+
+### How to Use
+
+The instructions are basically the same as [DO](#do-quick-start).
+
+The following are specific to Scaleway:
+
+- `scw_token` in the `terraform.tfvars` can be created in the `Account > Credentials > Tokens` section.
+- `scw_org` in the `terraform.tfvars` can be found in the `Account > ORGANIZATION ID` section.
+
+
+**Please be aware that you will be responsible for the usage charges with Digital Ocean**
+
 ## Vagrant quick start
 
 The vagrant folder contains a vagrant code to stand up a single Rancher server instance with a 3 node cluster attached to it.

--- a/scaleway/files/userdata_agent
+++ b/scaleway/files/userdata_agent
@@ -1,0 +1,104 @@
+#!/bin/bash -x
+export curlimage=appropriate/curl
+export jqimage=stedolan/jq
+export rancher_server_ip='${server_address}'
+
+if [ `command -v curl` ]; then
+  curl -sL https://releases.rancher.com/install-docker/${docker_version_agent}.sh | sh
+elif [ `command -v wget` ]; then
+  wget -qO- https://releases.rancher.com/install-docker/${docker_version_agent}.sh | sh
+fi
+
+for image in $curlimage $jqimage; do
+  until docker inspect $image > /dev/null 2>&1; do
+    docker pull $image
+    sleep 2
+  done
+done
+
+while true; do
+  docker run --rm $curlimage -sLk https://$rancher_server_ip/ping && break
+  sleep 5
+done
+
+# Login
+while true; do
+
+    LOGINRESPONSE=$(docker run \
+        --rm \
+        $curlimage \
+        -s "https://$rancher_server_ip/v3-public/localProviders/local?action=login" -H 'content-type: application/json' --data-binary '{"username":"admin","password":"${admin_password}"}' --insecure)
+    LOGINTOKEN=$(echo $LOGINRESPONSE | docker run --rm -i $jqimage -r .token)
+
+    if [ "$LOGINTOKEN" != "null" ]; then
+        break
+    else
+        sleep 5
+    fi
+done
+
+# Get the Agent Image from the rancher server
+while true; do
+  AGENTIMAGE=$(docker run \
+    --rm \
+    $curlimage \
+      -sLk \
+      -H "Authorization: Bearer $LOGINTOKEN" \
+      "https://$rancher_server_ip/v3/settings/agent-image" | docker run --rm -i $jqimage -r '.value')
+
+  if [ -n "$AGENTIMAGE" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+until docker inspect $AGENTIMAGE > /dev/null 2>&1; do
+  docker pull $AGENTIMAGE
+  sleep 2
+done
+
+# Test if cluster is created
+while true; do
+  CLUSTERID=$(docker run \
+    --rm \
+    $curlimage \
+      -sLk \
+      -H "Authorization: Bearer $LOGINTOKEN" \
+      "https://$rancher_server_ip/v3/clusters?name=${cluster_name}" | docker run --rm -i $jqimage -r '.data[].id')
+
+  if [ -n "$CLUSTERID" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+# Get role flags from hostname
+ROLEFLAG=`hostname | awk -F'-' '{ print $NF }'`
+if [[ "$ROLEFLAG" == "all" ]]; then
+  ROLEFLAG="all-roles"
+fi
+
+# Get token
+# Test if cluster is created
+while true; do
+  AGENTCMD=$(docker run \
+    --rm \
+    $curlimage \
+      -sLk \
+      -H "Authorization: Bearer $LOGINTOKEN" \
+      "https://$rancher_server_ip/v3/clusterregistrationtoken?clusterId=$CLUSTERID" | docker run --rm -i $jqimage -r '.data[].nodeCommand' | head -1)
+
+  if [ -n "$AGENTCMD" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+# Combine command and flags
+COMPLETECMD="$AGENTCMD --$ROLEFLAG"
+
+# Run command
+$COMPLETECMD

--- a/scaleway/files/userdata_server
+++ b/scaleway/files/userdata_server
@@ -1,0 +1,63 @@
+#!/bin/bash -x
+export curlimage=appropriate/curl
+export jqimage=stedolan/jq
+
+if [ `command -v curl` ]; then
+  curl -sL https://releases.rancher.com/install-docker/${docker_version_server}.sh | sh
+elif [ `command -v wget` ]; then
+  wget -qO- https://releases.rancher.com/install-docker/${docker_version_server}.sh | sh
+fi
+
+for image in $curlimage $jqimage "rancher/rancher:${rancher_version}"; do
+  until docker inspect $image > /dev/null 2>&1; do
+    docker pull $image
+    sleep 2
+  done
+done
+
+docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /root/rancher:/var/lib/rancher rancher/rancher:${rancher_version}
+
+while true; do
+  docker run --rm --net=host $curlimage -sLk https://127.0.0.1/ping && break
+  sleep 5
+done
+
+# Login
+while true; do
+
+    LOGINRESPONSE=$(docker run \
+        --rm \
+        --net=host \
+        $curlimage \
+        -s "https://127.0.0.1/v3-public/localProviders/local?action=login" -H 'content-type: application/json' --data-binary '{"username":"admin","password":"admin"}' --insecure)
+    LOGINTOKEN=$(echo $LOGINRESPONSE | docker run --rm -i $jqimage -r .token)
+    echo "Login Token is $LOGINTOKEN"
+    if [ "$LOGINTOKEN" != "null" ]; then
+        break
+    else
+        sleep 5
+    fi
+done
+
+
+# Change password
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/users?action=changepassword' -H 'content-type: application/json' -H "Authorization: Bearer $LOGINTOKEN" --data-binary '{"currentPassword":"admin","newPassword":"${admin_password}"}' --insecure
+
+# Create API key
+APIRESPONSE=$(docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/token' -H 'content-type: application/json' -H "Authorization: Bearer $LOGINTOKEN" --data-binary '{"type":"token","description":"automation"}' --insecure)
+
+# Extract and store token
+APITOKEN=`echo $APIRESPONSE | docker run --rm -i $jqimage -r .token`
+
+# Configure server-url
+RANCHER_SERVER="https://$(docker run --rm --net=host appropriate/curl -sLk http://169.254.42.42/conf?format=json | docker run --rm -i stedolan/jq -r '.public_ip.address')"
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/settings/server-url' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" -X PUT --data-binary '{"name":"server-url","value":"'$RANCHER_SERVER'"}' --insecure
+
+# Create cluster
+CLUSTERRESPONSE=$(docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/cluster' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{"type":"cluster","rancherKubernetesEngineConfig":{"addonJobTimeout":30,"ignoreDockerVersion":true,"sshAgentAuth":false,"type":"rancherKubernetesEngineConfig","authentication":{"type":"authnConfig","strategy":"x509"},"network":{"type":"networkConfig","plugin":"canal"},"ingress":{"type":"ingressConfig","provider":"nginx"},"services":{"type":"rkeConfigServices","kubeApi":{"podSecurityPolicy":false,"type":"kubeAPIService"},"etcd":{"snapshot":false,"type":"etcdService","extraArgs":{"heartbeat-interval":500,"election-timeout":5000}}}},"name":"${cluster_name}"}' --insecure)
+
+# Extract clusterid to use for generating the docker run command
+CLUSTERID=`echo $CLUSTERRESPONSE | docker run --rm -i $jqimage -r .id`
+
+# Generate registrationtoken
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/clusterregistrationtoken' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{"type":"clusterRegistrationToken","clusterId":"'$CLUSTERID'"}' --insecure

--- a/scaleway/main.tf
+++ b/scaleway/main.tf
@@ -1,0 +1,183 @@
+# Configure the Scaleway Provider
+provider "scaleway" {
+  organization = "${var.scw_org}"
+  token        = "${var.scw_token}"
+  region       = "${var.region}"
+}
+
+variable "scw_org" {}
+
+variable "scw_token" {}
+
+variable "prefix" {
+  default = "yourname"
+}
+
+variable "rancher_version" {
+  default = "latest"
+}
+
+variable "count_agent_all_nodes" {
+  default = "3"
+}
+
+variable "count_agent_etcd_nodes" {
+  default = "0"
+}
+
+variable "count_agent_controlplane_nodes" {
+  default = "0"
+}
+
+variable "count_agent_worker_nodes" {
+  default = "0"
+}
+
+variable "admin_password" {
+  default = "admin"
+}
+
+variable "cluster_name" {
+  default = "quickstart"
+}
+
+variable "region" {
+  default = "par1"
+}
+
+variable "docker_version_server" {
+  default = "17.03"
+}
+
+variable "docker_version_agent" {
+  default = "17.03"
+}
+
+variable "type" {
+  default = "START1-S"
+}
+
+data "scaleway_image" "xenial" {
+  architecture = "x86_64"
+  name         = "Ubuntu Xenial"
+}
+
+resource "scaleway_server" "rancherserver" {
+  count               = "1"
+  image               = "${data.scaleway_image.xenial.id}"
+  type                = "${var.type}"
+  name                = "${var.prefix}-rancherserver"
+  security_group      = "${scaleway_security_group.allowall.id}"
+  dynamic_ip_required = true
+}
+
+resource "scaleway_user_data" "rancherserver" {
+  server = "${scaleway_server.rancherserver.id}"
+  key    = "cloud-init"
+  value  = "${data.template_file.userdata_server.rendered}"
+}
+
+resource "scaleway_server" "rancheragent_all" {
+  count               = "${var.count_agent_all_nodes}"
+  image               = "${data.scaleway_image.xenial.id}"
+  type                = "${var.type}"
+  name                = "${var.prefix}-rancheragent-${count.index}-all"
+  security_group      = "${scaleway_security_group.allowall.id}"
+  dynamic_ip_required = true
+}
+
+resource "scaleway_user_data" "rancheragent_all" {
+  count  = "${var.count_agent_all_nodes}"
+  server = "${scaleway_server.rancheragent_all.*.id[count.index]}"
+  key    = "cloud-init"
+  value  = "${data.template_file.userdata_agent.rendered}"
+}
+
+resource "scaleway_server" "rancheragent_etcd" {
+  count               = "${var.count_agent_etcd_nodes}"
+  image               = "${data.scaleway_image.xenial.id}"
+  type                = "${var.type}"
+  name                = "${var.prefix}-rancheragent-${count.index}-etcd"
+  security_group      = "${scaleway_security_group.allowall.id}"
+  dynamic_ip_required = true
+}
+
+resource "scaleway_user_data" "rancheragent_etcd" {
+  count  = "${var.count_agent_etcd_nodes}"
+  server = "${scaleway_server.rancheragent_etcd.*.id[count.index]}"
+  key    = "cloud-init"
+  value  = "${data.template_file.userdata_agent.rendered}"
+}
+
+resource "scaleway_server" "rancheragent_controlplane" {
+  count               = "${var.count_agent_controlplane_nodes}"
+  image               = "${data.scaleway_image.xenial.id}"
+  type                = "${var.type}"
+  name                = "${var.prefix}-rancheragent-${count.index}-controlplane"
+  security_group      = "${scaleway_security_group.allowall.id}"
+  dynamic_ip_required = true
+}
+
+resource "scaleway_user_data" "rancheragent_controlplane" {
+  count  = "${var.count_agent_controlplane_nodes}"
+  server = "${scaleway_server.rancheragent_controlplane.*.id[count.index]}"
+  key    = "cloud-init"
+  value  = "${data.template_file.userdata_agent.rendered}"
+}
+
+resource "scaleway_server" "rancheragent_worker" {
+  count               = "${var.count_agent_worker_nodes}"
+  image               = "${data.scaleway_image.xenial.id}"
+  type                = "${var.type}"
+  name                = "${var.prefix}-rancheragent-${count.index}-worker"
+  security_group      = "${scaleway_security_group.allowall.id}"
+  dynamic_ip_required = true
+}
+
+resource "scaleway_user_data" "rancheragent_worker" {
+  count  = "${var.count_agent_worker_nodes}"
+  server = "${scaleway_server.rancheragent_worker.*.id[count.index]}"
+  key    = "cloud-init"
+  value  = "${data.template_file.userdata_agent.rendered}"
+}
+
+data "template_file" "userdata_server" {
+  template = "${file("files/userdata_server")}"
+
+  vars {
+    admin_password        = "${var.admin_password}"
+    cluster_name          = "${var.cluster_name}"
+    docker_version_server = "${var.docker_version_server}"
+    rancher_version       = "${var.rancher_version}"
+  }
+}
+
+data "template_file" "userdata_agent" {
+  template = "${file("files/userdata_agent")}"
+
+  vars {
+    admin_password       = "${var.admin_password}"
+    cluster_name         = "${var.cluster_name}"
+    docker_version_agent = "${var.docker_version_agent}"
+    rancher_version      = "${var.rancher_version}"
+    server_address       = "${scaleway_server.rancherserver.public_ip}"
+  }
+}
+
+resource "scaleway_security_group" "allowall" {
+  name        = "allowall"
+  description = "allow all traffic"
+}
+
+resource "scaleway_security_group_rule" "all_accept" {
+  security_group = "${scaleway_security_group.allowall.id}"
+
+  action    = "accept"
+  direction = "inbound"
+  ip_range  = "0.0.0.0/0"
+  protocol  = "TCP"
+}
+
+output "rancher-url" {
+  value = ["https://${scaleway_server.rancherserver.public_ip}"]
+}


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

I've added Scaleway as another choice for quick starting Rancher. There should be a certain amount of demands for their extremely low price servers (especially for development envs).

But Scaleway isn't mentioned in the quick start guides:

https://rancher.com/docs/rancher/v2.x/en/quick-start-guide/

so it may not make sense to add it here. I can create some docs for the above page if it is recommended to merge this PR.

Otherwise I'll close it and keep it to my own. Thank you!

How I tested:

- Tested with 3 `all-roles` agent nodes
- Tested with `etcd x 1`, `controlplane x 1`, `worker x 1` nodes