### PR TITLE
Configure default NAT interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ crash.log
 
 # terraform.tvars
 terraform.tfvars
+
+# vagrant files
+.vagrant/

--- a/vagrant/vagrant_rancheros_guest_plugin.rb
+++ b/vagrant/vagrant_rancheros_guest_plugin.rb
@@ -73,6 +73,9 @@ module VagrantPlugins
                             comm.sudo("ros config set rancher.network.interfaces.#{iface}.dhcp #{dhcp}")
                         end
 
+                        # Configure the default NAT interface
+                        comm.sudo("ros config set rancher.network.interfaces.eth0.dhcp true")
+                        comm.sudo("ros config set rancher.network.interfaces.eth0.match eth0")
                         comm.sudo("system-docker restart network")
                     end
                 end


### PR DESCRIPTION
Leaving the NAT interface unconfigured leaves the virtual machines
unusable upon restart.

Vagrant's virtualbox driver configures provisions the NAT interface and
the SSH ports are forwarded using that. If that is not brought up, the
VMs have no default route to the world outside.