### PR TITLE
Fixed data providers vars

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -248,7 +248,7 @@ resource "aws_instance" "rancheragent-worker" {
 data "template_file" "userdata_server" {
   template = "${file("files/userdata_server")}"
 
-  vars {
+  vars = {
     admin_password        = "${var.admin_password}"
     cluster_name          = "${var.cluster_name}"
     docker_version_server = "${var.docker_version_server}"
@@ -260,7 +260,7 @@ data "template_file" "userdata_server" {
 data "template_file" "userdata_agent" {
   template = "${file("files/userdata_agent")}"
 
-  vars {
+  vars = {
     admin_password       = "${var.admin_password}"
     cluster_name         = "${var.cluster_name}"
     docker_version_agent = "${var.docker_version_agent}"

--- a/do/main.tf
+++ b/do/main.tf
@@ -60,7 +60,6 @@ variable "ssh_keys" {
 }
 
 resource "digitalocean_droplet" "rancherserver" {
-  count     = "1"
   image     = "ubuntu-18-04-x64"
   name      = "${var.prefix}-rancherserver"
   region    = "${var.region}"
@@ -112,7 +111,7 @@ resource "digitalocean_droplet" "rancheragent-worker" {
 data "template_file" "userdata_server" {
   template = "${file("files/userdata_server")}"
 
-  vars {
+  vars = {
     admin_password        = "${var.admin_password}"
     cluster_name          = "${var.cluster_name}"
     docker_version_server = "${var.docker_version_server}"
@@ -123,7 +122,7 @@ data "template_file" "userdata_server" {
 data "template_file" "userdata_agent" {
   template = "${file("files/userdata_agent")}"
 
-  vars {
+  vars = {
     admin_password       = "${var.admin_password}"
     cluster_name         = "${var.cluster_name}"
     docker_version_agent = "${var.docker_version_agent}"


### PR DESCRIPTION
Fixes #38 by adding `=` to each instance of `vars {` for AWS and DO data providers. Reference: https://www.terraform.io/docs/providers/template/index.html

Also removes a superfluous configuration in the `digitalocean_droplet` DO resource.