### PR TITLE
Exoscale as a cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,49 @@
 
 ## Summary
 
-**NOTE:** Terraform 0.12.0 or higher is required for cloud based environments. (AWS and DigitalOcean)
+**NOTE:** Terraform 0.12.0 or higher is required for cloud based environments. (AWS, DigitalOcean, and Exoscale)
 
 This repo contains scripts that will allow you to quickly deploy and test Rancher for POC.
 The contents aren't intended for production but are here to get you up and going with running Rancher Server for a POC and to help show the functionality
+
+## Exoscale quick start
+
+**NOTE:** Terraform 0.12.0 or higher is required.
+
+The Exoscale folder contains terraform code to stand up a single Rancher server instance with a 3 node cluster attached to it.
+
+You will need the following:
+
+- An Exoscale API key and secret.
+- An Exoscale security group that has all internal connections allowed and accepts connections to port 443 from your IP.
+  It should also allow all internal connections.
+- An Exoscale SSH key pair to access the nodes.
+
+This terraform setup will:
+
+- Start an instance running `rancher/rancher` version specified in `rancher_version`
+- Create a custom cluster called `cluster_name`
+- Start `count_agent_all_nodes` amount of instances and add them to the custom cluster with all roles
+
+### How to use
+
+- Clone this repository and go into the Exoscale subfolder
+- Move the file `terraform.tfvars.example` to `terraform.tfvars` and edit (see inline explanation)
+- Run `terraform init`
+- Run `terraform apply`
+
+When provisioning has finished you will be given the url to connect to the Rancher Server
+
+### How to Remove
+
+To remove the VM's that have been deployed run `terraform destroy --force`
+
+### Optional adding nodes per role
+- Start `count_agent_etcd_nodes` amount of instances and add them to the custom cluster with etcd role
+- Start `count_agent_controlplane_nodes` amount of instances and add them to the custom cluster with controlplane role
+- Start `count_agent_worker_nodes` amount of instances and add them to the custom cluster with worker role
+
+**Please be aware that you will be responsible for the usage charges with Exoscale**
 
 ## DO quick start
 

--- a/exoscale/files/userdata_agent
+++ b/exoscale/files/userdata_agent
@@ -1,0 +1,104 @@
+#!/bin/bash -x
+export curlimage=appropriate/curl
+export jqimage=stedolan/jq
+export rancher_server_ip='${server_address}'
+
+if [ `command -v curl` ]; then
+  curl -sL https://releases.rancher.com/install-docker/${docker_version_agent}.sh | sh
+elif [ `command -v wget` ]; then
+  wget -qO- https://releases.rancher.com/install-docker/${docker_version_agent}.sh | sh
+fi
+
+for image in $curlimage $jqimage; do
+  until docker inspect $image > /dev/null 2>&1; do
+    docker pull $image
+    sleep 2
+  done
+done
+
+while true; do
+  docker run --rm $curlimage -sLk https://$rancher_server_ip/ping && break
+  sleep 5
+done
+
+# Login
+while true; do
+
+    LOGINRESPONSE=$(docker run \
+        --rm \
+        $curlimage \
+        -s "https://$rancher_server_ip/v3-public/localProviders/local?action=login" -H 'content-type: application/json' --data-binary '{"username":"admin","password":"${admin_password}"}' --insecure)
+    LOGINTOKEN=$(echo $LOGINRESPONSE | docker run --rm -i $jqimage -r .token)
+
+    if [ "$LOGINTOKEN" != "null" ]; then
+        break
+    else
+        sleep 5
+    fi
+done
+
+# Get the Agent Image from the rancher server
+while true; do
+  AGENTIMAGE=$(docker run \
+    --rm \
+    $curlimage \
+      -sLk \
+      -H "Authorization: Bearer $LOGINTOKEN" \
+      "https://$rancher_server_ip/v3/settings/agent-image" | docker run --rm -i $jqimage -r '.value')
+
+  if [ -n "$AGENTIMAGE" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+until docker inspect $AGENTIMAGE > /dev/null 2>&1; do
+  docker pull $AGENTIMAGE
+  sleep 2
+done
+
+# Test if cluster is created
+while true; do
+  CLUSTERID=$(docker run \
+    --rm \
+    $curlimage \
+      -sLk \
+      -H "Authorization: Bearer $LOGINTOKEN" \
+      "https://$rancher_server_ip/v3/clusters?name=${cluster_name}" | docker run --rm -i $jqimage -r '.data[].id')
+
+  if [ -n "$CLUSTERID" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+# Get role flags from hostname
+ROLEFLAG=`hostname | awk -F'-' '{ print $NF }'`
+if [[ "$ROLEFLAG" == "all" ]]; then
+  ROLEFLAG="all-roles"
+fi
+
+# Get token
+# Test if cluster is created
+while true; do
+  AGENTCMD=$(docker run \
+    --rm \
+    $curlimage \
+      -sLk \
+      -H "Authorization: Bearer $LOGINTOKEN" \
+      "https://$rancher_server_ip/v3/clusterregistrationtoken?clusterId=$CLUSTERID" | docker run --rm -i $jqimage -r '.data[].nodeCommand' | head -1)
+
+  if [ -n "$AGENTCMD" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+# Combine command and flags
+COMPLETECMD="$AGENTCMD --$ROLEFLAG"
+
+# Run command
+$COMPLETECMD

--- a/exoscale/files/userdata_server
+++ b/exoscale/files/userdata_server
@@ -1,0 +1,63 @@
+#!/bin/bash -x
+export curlimage=appropriate/curl
+export jqimage=stedolan/jq
+
+if [ `command -v curl` ]; then
+  curl -sL https://releases.rancher.com/install-docker/${docker_version_server}.sh | sh
+elif [ `command -v wget` ]; then
+  wget -qO- https://releases.rancher.com/install-docker/${docker_version_server}.sh | sh
+fi
+
+for image in $curlimage $jqimage "rancher/rancher:${rancher_version}"; do
+  until docker inspect $image > /dev/null 2>&1; do
+    docker pull $image
+    sleep 2
+  done
+done
+
+docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/rancher:/var/lib/rancher rancher/rancher:${rancher_version}
+
+while true; do
+  docker run --rm --net=host $curlimage -sLk https://127.0.0.1/ping && break
+  sleep 5
+done
+
+# Login
+while true; do
+
+    LOGINRESPONSE=$(docker run \
+        --rm \
+        --net=host \
+        $curlimage \
+        -s "https://127.0.0.1/v3-public/localProviders/local?action=login" -H 'content-type: application/json' --data-binary '{"username":"admin","password":"admin"}' --insecure)
+    LOGINTOKEN=$(echo $LOGINRESPONSE | docker run --rm -i $jqimage -r .token)
+    echo "Login Token is $LOGINTOKEN"
+    if [ "$LOGINTOKEN" != "null" ]; then
+        break
+    else
+        sleep 5
+    fi
+done
+
+
+# Change password
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/users?action=changepassword' -H 'content-type: application/json' -H "Authorization: Bearer $LOGINTOKEN" --data-binary '{"currentPassword":"admin","newPassword":"${admin_password}"}' --insecure
+
+# Create API key
+APIRESPONSE=$(docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/token' -H 'content-type: application/json' -H "Authorization: Bearer $LOGINTOKEN" --data-binary '{"type":"token","description":"automation"}' --insecure)
+
+# Extract and store token
+APITOKEN=`echo $APIRESPONSE | docker run --rm -i $jqimage -r .token`
+
+# Configure server-url
+RANCHER_SERVER="https://$(docker run --rm --net=host $curlimage -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)"
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/settings/server-url' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" -X PUT --data-binary '{"name":"server-url","value":"'$RANCHER_SERVER'"}' --insecure
+
+# Create cluster
+CLUSTERRESPONSE=$(docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/cluster' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{"dockerRootDir":"/var/lib/docker","enableNetworkPolicy":false,"type":"cluster","rancherKubernetesEngineConfig":{"addonJobTimeout":30,"ignoreDockerVersion":true,"sshAgentAuth":false,"type":"rancherKubernetesEngineConfig","authentication":{"type":"authnConfig","strategy":"x509"},"network":{"type":"networkConfig","plugin":"canal"},"ingress":{"type":"ingressConfig","provider":"nginx"},"monitoring":{"type":"monitoringConfig","provider":"metrics-server"},"services":{"type":"rkeConfigServices","kubeApi":{"podSecurityPolicy":false,"type":"kubeAPIService"},"etcd":{"creation":"12h","extraArgs":{"heartbeat-interval":500,"election-timeout":5000},"retention":"72h","snapshot":false,"type":"etcdService","backupConfig":{"enabled":true,"intervalHours":12,"retention":6,"type":"backupConfig"}}}},"localClusterAuthEndpoint":{"enabled":true,"type":"localClusterAuthEndpoint"},"name":"${cluster_name}"}' --insecure)
+
+# Extract clusterid to use for generating the docker run command
+CLUSTERID=`echo $CLUSTERRESPONSE | docker run --rm -i $jqimage -r .id`
+
+# Generate registrationtoken
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/clusterregistrationtoken' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{"type":"clusterRegistrationToken","clusterId":"'$CLUSTERID'"}' --insecure

--- a/exoscale/files/userdata_server
+++ b/exoscale/files/userdata_server
@@ -53,6 +53,9 @@ APITOKEN=`echo $APIRESPONSE | docker run --rm -i $jqimage -r .token`
 RANCHER_SERVER="https://$(docker run --rm --net=host $curlimage -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)"
 docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/settings/server-url' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" -X PUT --data-binary '{"name":"server-url","value":"'$RANCHER_SERVER'"}' --insecure
 
+# Enable Exoscale node driver
+docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/nodeDrivers/exoscale?action=activate' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{}' --insecure
+
 # Create cluster
 CLUSTERRESPONSE=$(docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/cluster' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{"dockerRootDir":"/var/lib/docker","enableNetworkPolicy":false,"type":"cluster","rancherKubernetesEngineConfig":{"addonJobTimeout":30,"ignoreDockerVersion":true,"sshAgentAuth":false,"type":"rancherKubernetesEngineConfig","authentication":{"type":"authnConfig","strategy":"x509"},"network":{"type":"networkConfig","plugin":"canal"},"ingress":{"type":"ingressConfig","provider":"nginx"},"monitoring":{"type":"monitoringConfig","provider":"metrics-server"},"services":{"type":"rkeConfigServices","kubeApi":{"podSecurityPolicy":false,"type":"kubeAPIService"},"etcd":{"creation":"12h","extraArgs":{"heartbeat-interval":500,"election-timeout":5000},"retention":"72h","snapshot":false,"type":"etcdService","backupConfig":{"enabled":true,"intervalHours":12,"retention":6,"type":"backupConfig"}}}},"localClusterAuthEndpoint":{"enabled":true,"type":"localClusterAuthEndpoint"},"name":"${cluster_name}"}' --insecure)
 

--- a/exoscale/main.tf
+++ b/exoscale/main.tf
@@ -1,0 +1,169 @@
+# Configure the Exoscale Provider
+provider "exoscale" {
+  key = var.exoscale_key
+  secret = var.exoscale_secret
+}
+
+variable "exoscale_key" {
+  default = "EXOxxx"
+}
+
+variable "exoscale_secret" {
+  default = "xxx"
+}
+
+variable "prefix" {
+  default = "yourname"
+}
+
+variable "rancher_version" {
+  default = "latest"
+}
+
+variable "count_agent_all_nodes" {
+  default = "3"
+}
+
+variable "count_agent_etcd_nodes" {
+  default = "0"
+}
+
+variable "count_agent_controlplane_nodes" {
+  default = "0"
+}
+
+variable "count_agent_worker_nodes" {
+  default = "0"
+}
+
+variable "admin_password" {
+  default = "admin"
+}
+
+variable "cluster_name" {
+  default = "quickstart"
+}
+
+variable "zone" {
+  default = "at-vie-1"
+}
+
+variable "size" {
+  default = "Medium"
+}
+
+variable "disk_size" {
+  type = number
+  default = 80
+}
+
+variable "security_groups" {
+  type = list(string)
+  default = ["default"]
+}
+
+variable "docker_version_server" {
+  default = "18.09"
+}
+
+variable "docker_version_agent" {
+  default = "18.09"
+}
+
+variable "ssh_key" {
+  type = string
+  default = ""
+}
+
+data "exoscale_compute_template" "ubuntu" {
+  zone = var.zone
+  name = "Linux Ubuntu 18.04 LTS 64-bit"
+}
+
+resource "exoscale_compute" "rancherserver" {
+  count           = "1"
+  template_id     = data.exoscale_compute_template.ubuntu.id
+  display_name    = "${var.prefix}-rancherserver"
+  zone            = var.zone
+  size            = var.size
+  user_data       = data.template_file.userdata_server.rendered
+  disk_size       = var.disk_size
+  key_pair        = var.ssh_key
+  security_groups = var.security_groups
+}
+
+resource "exoscale_compute" "rancheragent-all" {
+  count           = var.count_agent_all_nodes
+  template_id     = data.exoscale_compute_template.ubuntu.id
+  display_name    = "${var.prefix}-rancheragent-${count.index}-all"
+  zone            = var.zone
+  size            = var.size
+  disk_size       = var.disk_size
+  user_data       = data.template_file.userdata_agent.rendered
+  key_pair        = var.ssh_key
+  security_groups = var.security_groups
+}
+
+resource "exoscale_compute" "rancheragent-etcd" {
+  count           = var.count_agent_etcd_nodes
+  template_id     = data.exoscale_compute_template.ubuntu.id
+  display_name    = "${var.prefix}-rancheragent-${count.index}-etcd"
+  zone            = var.zone
+  size            = var.size
+  disk_size       = var.disk_size
+  user_data       = data.template_file.userdata_agent.rendered
+  key_pair        = var.ssh_key
+  security_groups = var.security_groups
+}
+
+resource "exoscale_compute" "rancheragent-controlplane" {
+  count           = var.count_agent_controlplane_nodes
+  template_id     = data.exoscale_compute_template.ubuntu.id
+  display_name    = "${var.prefix}-rancheragent-${count.index}-controlplane"
+  zone            = var.zone
+  size            = var.size
+  disk_size       = var.disk_size
+  user_data       = data.template_file.userdata_agent.rendered
+  key_pair        = var.ssh_key
+  security_groups = var.security_groups
+}
+
+resource "exoscale_compute" "rancheragent-worker" {
+  count           = var.count_agent_worker_nodes
+  template_id     = data.exoscale_compute_template.ubuntu.id
+  display_name    = "${var.prefix}-rancheragent-${count.index}-worker"
+  zone            = var.zone
+  size            = var.size
+  disk_size       = var.disk_size
+  user_data       = data.template_file.userdata_agent.rendered
+  key_pair        = var.ssh_key
+  security_groups = var.security_groups
+}
+
+data "template_file" "userdata_server" {
+  template = file("files/userdata_server")
+
+  vars = {
+    admin_password        = var.admin_password
+    cluster_name          = var.cluster_name
+    docker_version_server = var.docker_version_server
+    rancher_version       = var.rancher_version
+  }
+}
+
+data "template_file" "userdata_agent" {
+  template = file("files/userdata_agent")
+
+  vars = {
+    admin_password       = var.admin_password
+    cluster_name         = var.cluster_name
+    docker_version_agent = var.docker_version_agent
+    rancher_version      = var.rancher_version
+    server_address       = exoscale_compute.rancherserver[0].ip_address
+  }
+}
+
+output "rancher-url" {
+  value = ["https://${exoscale_compute.rancherserver[0].ip_address}"]
+}
+

--- a/exoscale/terraform.tfvars.example
+++ b/exoscale/terraform.tfvars.example
@@ -1,0 +1,36 @@
+# Exoscale API key
+exoscale_key = "EXO***"
+# Exoscale API secret
+exoscale_secret = "***"
+# Admin password to access Rancher
+admin_password = "admin"
+# Name of custom cluster that will be created
+cluster_name = "quickstart"
+# Resources will be prefixed with this to avoid clashing names
+prefix = "myname"
+# rancher/rancher image tag to use
+rancher_version = "latest"
+# Zone where resources should be created
+zone = "at-vie-1"
+# Security groups the cluster should run in:
+security_groups = ["default"]
+# Count of agent nodes with role all
+count_agent_all_nodes = "1"
+# Count of agent nodes with role etcd
+count_agent_etcd_nodes = "0"
+# Count of agent nodes with role controlplane
+count_agent_controlplane_nodes = "0"
+# Count of agent nodes with role worker
+count_agent_worker_nodes = "0"
+# Docker version of host running `rancher/rancher`
+docker_version_server = "18.09"
+# Docker version of host being added to a cluster (running `rancher/rancher-agent`)
+docker_version_agent = "18.09"
+# Instance size
+size = "Medium"
+# Instance disk size
+disk_size = 80
+# Exoscale SSH key to embed in the instance
+# ssh_keys = "your-key-name"
+# If this is not specified, you will not be able to log in to the underlying server
+ssh_key = ""

--- a/exoscale/versions.tf
+++ b/exoscale/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This pull request implements [Exoscale](https://www.exoscale.com/) as an example to be deployed on.

The implementation is as close to the existing DO example as possible, with the following:

- Exoscale only supports a single SSH key on an instance
- Exoscale requires a security group for instances
- The userdata_server script has been adapted to enable Exoscale as a node driver.

The documentation, of course, has been adapted as well.