### PR TITLE
Use full path to yaml file to allow global vagrant commands

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,7 +4,7 @@ require_relative 'vagrant_rancheros_guest_plugin.rb'
 require 'ipaddr'
 require 'yaml'
 
-x = YAML.load_file('config.yaml')
+x = YAML.load_file(File.join(File.dirname(__FILE__), 'config.yaml'))
 puts "Config: #{x.inspect}\n\n"
 
 $private_nic_type = x.fetch('net').fetch('private_nic_type')


### PR DESCRIPTION
Running a command like 'vagrant global-status' would work
in this directory but fail in others. Prepending the path
to the Vagrantfile solves this.