### PR TITLE
Add .vagrant folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ crash.log
 
 # terraform.tvars
 terraform.tfvars
+
+# vagrant state directory
+.vagrant


### PR DESCRIPTION
This adds the `.vagrant` folder where the vagrant state is stored in to `.gitignore`.