### PR TITLE
Add a flag to toggle use of SSH agent.

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -11,7 +11,6 @@ aws_secret_key = ""
 # Password used to log in to the `admin` account on the new Rancher server
 rancher_server_admin_password = ""
 
-
 # Optional variables, uncomment to customize the quickstart
 # ----------------------------------------------------------
 
@@ -33,6 +32,10 @@ rancher_server_admin_password = ""
 # - Public key is assumed to be at "${ssh_key_file_name}.pub" (e.g. ~/.ssh/id_rsa_do.pub)
 # ssh_key_file_name = ""
 
+# Override instance/SSH behaviour
+# - Uncomment if your private key has a passphrase and is handled by an SSH agent
+# override_ssh_agent = true
+
 # Kubernetes version used for creating management server cluster
 # - Must be supported by RKE terraform provider 0.14.1
 # rke_kubernetes_version = ""
@@ -46,4 +49,3 @@ rancher_server_admin_password = ""
 
 # Version of Rancher to install
 # rancher_version = ""
-

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -74,6 +74,11 @@ variable "rancher_server_admin_password" {
   description = "Admin password to use for Rancher server bootstrap"
 }
 
+# Override instance/SSH behaviour, for private keys protected by passphrases and managed by an SSH agent
+variable "override_ssh_agent" {
+  type    = bool
+  default = null
+}
 
 # Local variables used to reduce repetition
 locals {


### PR DESCRIPTION
When the SSH private key has a passphrase, is managed by an SSH agent, and the `agent` flag in the SSH `connection` blocks of the two `aws_instance` resources are set to `true`, then setting `private_key` as well in the same block is counter-productive, as Terraform will follow the `private_key` value before checking with the SSH agent, load the encrypted key first, and subsequently fail with the following:

```
Error: Failed to parse ssh private key: ssh: cannot decode encrypted private keys
```
This is worked around with [an override flag](https://github.com/jlucktay/quickstart/blob/2dc640b88744024b583f1d492bd5329853530b0e/aws/terraform.tfvars.example#L35-L37) to toggle the behaviour appropriately.

Ref:
- https://github.com/hashicorp/terraform/issues/13734#issuecomment-295061898
- https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements/
