### PR TITLE
Update rancher2 provider to version 1.8.3

### DIFF
--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -42,7 +42,7 @@ provider "helm" {
 
 # Rancher2 bootstrapping provider
 provider "rancher2" {
-  version = "1.7.3"
+  version = "1.8.3"
 
   alias = "bootstrap"
 
@@ -54,7 +54,7 @@ provider "rancher2" {
 
 # Rancher2 administration provider
 provider "rancher2" {
-  version = "1.7.3"
+  version = "1.8.3"
 
   alias = "admin"
 


### PR DESCRIPTION
Update rancher2 provider to version 1.8.3 to use latest provider version.

Closes #71 