### PR TITLE
Quiet down cloud-init logs

### DIFF
--- a/aws/infra.tf
+++ b/aws/infra.tf
@@ -48,7 +48,9 @@ resource "aws_instance" "rancher_server" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {
@@ -104,7 +106,9 @@ resource "aws_instance" "quickstart_node" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {

--- a/azure/infra.tf
+++ b/azure/infra.tf
@@ -102,7 +102,9 @@ resource "azurerm_linux_virtual_machine" "rancher_server" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {
@@ -207,7 +209,9 @@ resource "azurerm_linux_virtual_machine" "quickstart-node" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {

--- a/do/infra.tf
+++ b/do/infra.tf
@@ -25,7 +25,9 @@ resource "digitalocean_droplet" "rancher_server" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {
@@ -82,7 +84,9 @@ resource "digitalocean_droplet" "quickstart_node" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {

--- a/gcp/infra.tf
+++ b/gcp/infra.tf
@@ -54,7 +54,9 @@ resource "google_compute_instance" "rancher_server" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {
@@ -119,7 +121,9 @@ resource "google_compute_instance" "quickstart_node" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
     ]
 
     connection {


### PR DESCRIPTION
Cloud-init logs leave loads of `.` lines in the terminal. Remove these, as the logs don't indicate success or failure of the cloud init scripts.