### PR TITLE
Fix GCP dependencies and example variables

### DIFF
--- a/gcp/infra.tf
+++ b/gcp/infra.tf
@@ -24,6 +24,10 @@ resource "google_compute_firewall" "rancher_fw_allowall" {
 
 # GCP Compute Instance for creating a single node RKE cluster and installing the Rancher server
 resource "google_compute_instance" "rancher_server" {
+  depends_on = [
+    google_compute_firewall.rancher_fw_allowall,
+  ]
+
   name         = "${var.prefix}-rancher-server"
   machine_type = var.machine_type
   zone         = var.gcp_zone
@@ -90,6 +94,10 @@ module "rancher_common" {
 
 # GCP compute instance for creating a single node workload cluster
 resource "google_compute_instance" "quickstart_node" {
+  depends_on = [
+    google_compute_firewall.rancher_fw_allowall,
+  ]
+
   name         = "${var.prefix}-quickstart-node"
   machine_type = var.machine_type
   zone         = var.gcp_zone

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -6,6 +6,9 @@
 # - Specify full path and name (e.g. ~/.gcp/account.json)
 gcp_account_json = ""
 
+# Project to deploy resources into
+gcp_project = ""
+
 # Password used to log in to the `admin` account on the new Rancher server
 rancher_server_admin_password = ""
 


### PR DESCRIPTION
Add GCP explicit firewall dependency for successful destroy, add missing GCP variable to example tfvars file.

