### PR TITLE
Add full rke provider installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,76 @@ This setup provides easy access to the core Rancher functionality while establis
 ### Requirements - Cloud
 
 - Terraform >=0.12.0
-- RKE terraform provider version 1.0.0 installed locally - see [`Using the provider` in rancher/terraform-provider-rke](https://github.com/rancher/terraform-provider-rke#using-the-provider) for installation instructions
+- RKE terraform provider version 1.0.0 installed locally - full install instructions [below](#installing-terraform-provider-rke)
 - Credentials for the cloud provider used for the quickstart
+
+#### Installing terraform-provider-rke
+
+##### Linux
+
+###### 64-bit
+
+Download [the v1.0.0 release archive for Linux](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-linux-amd64.tar.gz),
+extract the archive, and move the binary in `terraform-provider-rke-9c95410` to
+`~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.0`.
+
+If curl and tar are installed, you can use the following script:
+```sh
+curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-linux-amd64.tar.gz && \
+tar -xzvf terraform-provider-rke-linux-amd64.tar.gz && \
+chmod +x ./terraform-provider-rke-9c95410/terraform-provider-rke && \
+mkdir -p ~/.terraform.d/plugins/linux_amd64/ && \
+mv ./terraform-provider-rke-9c95410/terraform-provider-rke ~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.0
+rm -rf ./terraform-provider-rke-*
+```
+
+##### MacOS
+
+Download [the v1.0.0 release archive for MacOS](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-darwin-amd64.tar.gz),
+extract the archive, and move the binary in `terraform-provider-rke-9c95410` to
+`~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.0`.
+
+If curl and tar are installed, you can use the following script:
+```sh
+curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-darwin-amd64.tar.gz && \
+tar -xzvf terraform-provider-rke-darwin-amd64.tar.gz && \
+chmod +x ./terraform-provider-rke-9c95410/terraform-provider-rke && \
+mkdir -p ~/.terraform.d/plugins/darwin_amd64/ && \
+mv ./terraform-provider-rke-9c95410/terraform-provider-rke ~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.0
+rm -rf ./terraform-provider-rke-*
+```
+
+##### Windows
+
+###### 64-bit
+
+Download [the v1.0.0 release archive for Windows (64-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-amd64.zip),
+extract the archive, and move the executable in `terraform-provider-rke-9c95410` to
+`%APPDATA%\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.0.exe`.
+
+You can use the following PowerShell script to perform the same steps (tested with PS version 5.1):
+```
+New-Item -Path $Env:APPDATA\terraform.d\plugins\windows_amd64 -ItemType Directory -Force
+Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-amd64.zip -OutFile terraform-provider-rke-windows-amd64.zip -UseBasicParsing
+Expand-Archive terraform-provider-rke-windows-amd64.zip
+Move-Item -Path terraform-provider-rke-windows-amd64\terraform-provider-rke-9c95410\terraform-provider-rke.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.0.exe
+Remove-Item -Path terraform-provider-rke-windows-amd64* -Recurse
+```
+
+###### 32-bit
+
+Download [the v1.0.0 release archive for Windows (32-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-386.zip),
+extract the archive, and move the executable in `terraform-provider-rke-9c95410` to
+`%APPDATA%\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.0.exe`.
+
+You can use the following PowerShell script to perform the same steps (tested with PS version 5.1):
+```
+Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-386.zip -OutFile terraform-provider-rke-windows-386.zip -UseBasicParsing
+New-Item -Path $Env:APPDATA\terraform.d\plugins\windows_386 -ItemType Directory -Force
+Expand-Archive terraform-provider-rke-windows-386.zip
+Move-Item -Path terraform-provider-rke-windows-386\terraform-provider-rke-9c95410\terraform-provider-rke.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.0.exe
+Remove-Item -Path terraform-provider-rke-windows-386* -Recurse
+```
 
 ### Deploy
 


### PR DESCRIPTION
Adds complete installation instructions and scripts for the required version of `terraform-provider-rke`, removing need for external link to generic installation instructions.