### PR TITLE
Use AWS public IPs

### DIFF
--- a/aws/files/userdata_quickstart_node.template
+++ b/aws/files/userdata_quickstart_node.template
@@ -1,0 +1,11 @@
+#!/bin/bash -x
+
+curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
+sudo usermod -aG docker ${username}
+
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+
+publicIP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/public-ipv4)
+privateIP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/local-ipv4)
+
+${register_command} --address $publicIP --internal-address $privateIP --etcd --controlplane --worker

--- a/aws/infra.tf
+++ b/aws/infra.tf
@@ -112,7 +112,7 @@ resource "aws_instance" "quickstart_node" {
   security_groups = [aws_security_group.rancher_sg_allowall.name]
 
   user_data = templatefile(
-    join("/", [path.module, "../cloud-common/files/userdata_quickstart_node.template"]),
+    join("/", [path.module, "files/userdata_quickstart_node.template"]),
     {
       docker_version   = var.docker_version
       username         = local.node_username


### PR DESCRIPTION
Specify public and private IPs explicitly in all node registration commands.

Related issue:
#90