### PR TITLE
Use GCP Public IPs

### DIFF
--- a/gcp/files/userdata_quickstart_node.template
+++ b/gcp/files/userdata_quickstart_node.template
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
+sudo usermod -aG docker ${username}
+
+privateIP=$(curl -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
+
+${register_command} --address ${public_ip} --internal-address $privateIP --etcd --controlplane --worker

--- a/gcp/infra.tf
+++ b/gcp/infra.tf
@@ -134,11 +134,12 @@ resource "google_compute_instance" "quickstart_node" {
   metadata = {
     ssh-keys = "ubuntu:${tls_private_key.global_key.public_key_openssh}"
     user-data = templatefile(
-      join("/", [path.module, "../cloud-common/files/userdata_quickstart_node.template"]),
+      join("/", [path.module, "files/userdata_quickstart_node.template"]),
       {
         docker_version   = var.docker_version
         username         = local.node_username
         register_command = module.rancher_common.custom_cluster_command
+        public_ip        = google_compute_address.quickstart_node_address.address
       }
     )
   }


### PR DESCRIPTION
Specify public and private ips specifically in GCP node registration command

Fixes https://github.com/rancher/quickstart/issues/96