### PR TITLE
Set DEBIAN_FRONTEND envvar to noninteractive

### DIFF
--- a/aws/files/userdata_quickstart_node.template
+++ b/aws/files/userdata_quickstart_node.template
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+export DEBIAN_FRONTEND=noninteractive
 curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
 sudo usermod -aG docker ${username}
 

--- a/azure-windows/files/userdata_quickstart_node.template
+++ b/azure-windows/files/userdata_quickstart_node.template
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+export DEBIAN_FRONTEND=noninteractive
 curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
 sudo usermod -aG docker ${username}
 

--- a/azure/files/userdata_quickstart_node.template
+++ b/azure/files/userdata_quickstart_node.template
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+export DEBIAN_FRONTEND=noninteractive
 curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
 sudo usermod -aG docker ${username}
 

--- a/cloud-common/files/userdata_quickstart_node.template
+++ b/cloud-common/files/userdata_quickstart_node.template
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+export DEBIAN_FRONTEND=noninteractive
 curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
 sudo usermod -aG docker ${username}
 

--- a/cloud-common/files/userdata_rancher_server.template
+++ b/cloud-common/files/userdata_rancher_server.template
@@ -1,4 +1,5 @@
 #!/bin/bash -x
 
+export DEBIAN_FRONTEND=noninteractive
 curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
 sudo usermod -aG docker ${username}

--- a/gcp/files/userdata_quickstart_node.template
+++ b/gcp/files/userdata_quickstart_node.template
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 
+export DEBIAN_FRONTEND=noninteractive
 curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
 sudo usermod -aG docker ${username}
 


### PR DESCRIPTION
Ensure that the installation on Debian derivatives (including Ubuntu) doesn't hang waiting for user input.  This can occassionally happen when other packages are installed or upgraded as dependencies.