### PR TITLE
Bump terraform providers and k8s versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This setup provides easy access to the core Rancher functionality while establis
 ### Requirements - Cloud
 
 - Terraform >=0.12.0
-- RKE terraform provider version 1.0.0 installed locally - full install instructions [below](#installing-terraform-provider-rke)
+- RKE terraform provider version 1.0.1 installed locally - full install instructions [below](#installing-terraform-provider-rke)
 - Credentials for the cloud provider used for the quickstart
 
 #### Installing terraform-provider-rke
@@ -48,66 +48,66 @@ This setup provides easy access to the core Rancher functionality while establis
 
 ###### 64-bit
 
-Download [the v1.0.0 release archive for Linux](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-linux-amd64.tar.gz),
-extract the archive, and move the binary in `terraform-provider-rke-9c95410` to
-`~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.0`.
+Download [the v1.0.1 release archive for Linux](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_linux_amd64.zip),
+extract the archive, and move the binary to
+`~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.1`.
 
-If curl and tar are installed, you can use the following script:
+If curl and unzip are installed, you can use the following script:
 ```sh
-curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-linux-amd64.tar.gz && \
-tar -xzvf terraform-provider-rke-linux-amd64.tar.gz && \
-chmod +x ./terraform-provider-rke-9c95410/terraform-provider-rke && \
+curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_linux_amd64.zip && \
+unzip terraform-provider-rke_1.0.1_linux_amd64.zip && \
+chmod +x ./terraform-provider-rke_v1.0.1 && \
 mkdir -p ~/.terraform.d/plugins/linux_amd64/ && \
-mv ./terraform-provider-rke-9c95410/terraform-provider-rke ~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.0
-rm -rf ./terraform-provider-rke-*
+mv ./terraform-provider-rke_v1.0.1 ~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.1
+rm -rf ./terraform-provider-rke_*
 ```
 
 ##### MacOS
 
-Download [the v1.0.0 release archive for MacOS](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-darwin-amd64.tar.gz),
-extract the archive, and move the binary in `terraform-provider-rke-9c95410` to
-`~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.0`.
+Download [the v1.0.1 release archive for MacOS](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_darwin_amd64.zip),
+extract the archive, and move the binary to
+`~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.1`.
 
-If curl and tar are installed, you can use the following script:
+If curl and unzip are installed, you can use the following script:
 ```sh
-curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-darwin-amd64.tar.gz && \
-tar -xzvf terraform-provider-rke-darwin-amd64.tar.gz && \
-chmod +x ./terraform-provider-rke-9c95410/terraform-provider-rke && \
+curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_darwin_amd64.zip && \
+unzip terraform-provider-rke_1.0.1_darwin_amd64.zip && \
+chmod +x ./terraform-provider-rke_v1.0.1 && \
 mkdir -p ~/.terraform.d/plugins/darwin_amd64/ && \
-mv ./terraform-provider-rke-9c95410/terraform-provider-rke ~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.0
-rm -rf ./terraform-provider-rke-*
+mv ./terraform-provider-rke_v1.0.1 ~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.1
+rm -rf ./terraform-provider-rke_*
 ```
 
 ##### Windows
 
 ###### 64-bit
 
-Download [the v1.0.0 release archive for Windows (64-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-amd64.zip),
-extract the archive, and move the executable in `terraform-provider-rke-9c95410` to
-`%APPDATA%\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.0.exe`.
+Download [the v1.0.1 release archive for Windows (64-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_amd64.zip),
+extract the archive, and move the executable to
+`%APPDATA%\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.1.exe`.
 
 You can use the following PowerShell script to perform the same steps (tested with PS version 5.1):
 ```
 New-Item -Path $Env:APPDATA\terraform.d\plugins\windows_amd64 -ItemType Directory -Force
-Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-amd64.zip -OutFile terraform-provider-rke-windows-amd64.zip -UseBasicParsing
-Expand-Archive terraform-provider-rke-windows-amd64.zip
-Move-Item -Path terraform-provider-rke-windows-amd64\terraform-provider-rke-9c95410\terraform-provider-rke.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.0.exe
-Remove-Item -Path terraform-provider-rke-windows-amd64* -Recurse
+Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_amd64.zip -OutFile terraform-provider-rke_1.0.1_windows_amd64.zip -UseBasicParsing
+Expand-Archive terraform-provider-rke_1.0.1_windows_amd64.zip
+Move-Item -Path terraform-provider-rke_1.0.1_windows_amd64\terraform-provider-rke_v1.0.1.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.1.exe
+Remove-Item -Path terraform-provider-rke_1.0.1_windows_amd64* -Recurse
 ```
 
 ###### 32-bit
 
-Download [the v1.0.0 release archive for Windows (32-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-386.zip),
-extract the archive, and move the executable in `terraform-provider-rke-9c95410` to
-`%APPDATA%\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.0.exe`.
+Download [the v1.0.1 release archive for Windows (32-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_386.zip),
+extract the archive, and move the executable to
+`%APPDATA%\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.1.exe`.
 
 You can use the following PowerShell script to perform the same steps (tested with PS version 5.1):
 ```
-Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/1.0.0/terraform-provider-rke-windows-386.zip -OutFile terraform-provider-rke-windows-386.zip -UseBasicParsing
+Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_386.zip -OutFile terraform-provider-rke_1.0.1_windows_386.zip -UseBasicParsing
 New-Item -Path $Env:APPDATA\terraform.d\plugins\windows_386 -ItemType Directory -Force
-Expand-Archive terraform-provider-rke-windows-386.zip
-Move-Item -Path terraform-provider-rke-windows-386\terraform-provider-rke-9c95410\terraform-provider-rke.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.0.exe
-Remove-Item -Path terraform-provider-rke-windows-386* -Recurse
+Expand-Archive terraform-provider-rke_1.0.1_windows_386.zip
+Move-Item -Path terraform-provider-rke_1.0.1_windows_386\terraform-provider-rke_v1.0.1.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.1.exe
+Remove-Item -Path terraform-provider-rke_1.0.1_windows_386* -Recurse
 ```
 
 ### Deploy

--- a/aws/README.md
+++ b/aws/README.md
@@ -31,13 +31,13 @@ Instance type used for all EC2 instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.15.3-rancher1-1"`**
+- Default: **`"v1.18.3-rancher2-2"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"1.16.6-rancher1-2"`**
+- Default: **`"v1.17.6-rancher2-2"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -49,7 +49,7 @@ Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.3.5"`**
+- Default: **`"v2.4.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/aws/infra.tf
+++ b/aws/infra.tf
@@ -62,6 +62,10 @@ resource "aws_instance" "rancher_server" {
     }
   )
 
+  root_block_device {
+    volume_size = 16
+  }
+
   provisioner "remote-exec" {
     inline = [
       "echo 'Waiting for cloud-init to complete...'",
@@ -96,7 +100,8 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = aws_instance.rancher_server.public_dns
+  rancher_server_dns = join(".", ["rancher", aws_instance.rancher_server.public_ip, "xip.io"])
+
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -29,11 +29,11 @@ rancher_server_admin_password = ""
 # docker_version = ""
 
 # Kubernetes version used for creating management server cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # rke_kubernetes_version = ""
 
 # Kubernetes version used for creating workload cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # workload_kubernetes_version = ""
 
 # Version of cert-manager to install, used in case of older Rancher versions

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -41,13 +41,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.15.3-rancher1-1"
+  default     = "v1.18.3-rancher2-2"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.16.6-rancher1-2"
+  default     = "v1.17.6-rancher2-2"
 }
 
 variable "cert_manager_version" {

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -40,13 +40,13 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.15.3-rancher1-1"`**
+- Default: **`"v1.18.3-rancher2-2"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"1.16.6-rancher1-2"`**
+- Default: **`"v1.17.6-rancher2-2"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -58,7 +58,7 @@ Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.3.5"`**
+- Default: **`"v2.4.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure-windows/infra.tf
+++ b/azure-windows/infra.tf
@@ -145,7 +145,8 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = "${replace(azurerm_linux_virtual_machine.rancher_server.public_ip_address, ".", "-")}.nip.io"
+  rancher_server_dns = join(".", ["rancher", azurerm_linux_virtual_machine.rancher_server.public_ip_address, "xip.io"])
+
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version

--- a/azure-windows/terraform.tfvars.example
+++ b/azure-windows/terraform.tfvars.example
@@ -37,11 +37,11 @@ windows_admin_password = ""
 # docker_version = ""
 
 # Kubernetes version used for creating management server cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # rke_kubernetes_version = ""
 
 # Kubernetes version used for creating workload cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # workload_kubernetes_version = ""
 
 # Version of cert-manager to install, used in case of older Rancher versions

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -47,13 +47,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.15.3-rancher1-1"
+  default     = "v1.18.3-rancher2-2"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.16.6-rancher1-2"
+  default     = "v1.17.6-rancher2-2"
 }
 
 variable "cert_manager_version" {

--- a/azure/README.md
+++ b/azure/README.md
@@ -39,13 +39,13 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.15.3-rancher1-1"`**
+- Default: **`"v1.18.3-rancher2-2"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"1.16.6-rancher1-2"`**
+- Default: **`"v1.17.6-rancher2-2"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -57,7 +57,7 @@ Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.3.5"`**
+- Default: **`"v2.4.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure/infra.tf
+++ b/azure/infra.tf
@@ -145,7 +145,8 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = "${replace(azurerm_linux_virtual_machine.rancher_server.public_ip_address, ".", "-")}.nip.io"
+  rancher_server_dns = join(".", ["rancher", azurerm_linux_virtual_machine.rancher_server.public_ip_address, "xip.io"])
+
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -34,11 +34,11 @@ rancher_server_admin_password = ""
 # docker_version = ""
 
 # Kubernetes version used for creating management server cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # rke_kubernetes_version = ""
 
 # Kubernetes version used for creating workload cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # workload_kubernetes_version = ""
 
 # Version of cert-manager to install, used in case of older Rancher versions

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -47,13 +47,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.15.3-rancher1-1"
+  default     = "v1.18.3-rancher2-2"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.16.6-rancher1-2"
+  default     = "v1.17.6-rancher2-2"
 }
 
 variable "cert_manager_version" {

--- a/do/README.md
+++ b/do/README.md
@@ -26,13 +26,13 @@ Droplet size used for all droplets
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.15.3-rancher1-1"`**
+- Default: **`"v1.18.3-rancher2-2"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.16.6-rancher1-2"`**
+- Default: **`"v1.17.6-rancher2-2"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -44,7 +44,7 @@ Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.3.5"`**
+- Default: **`"v2.4.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/do/terraform.tfvars.example
+++ b/do/terraform.tfvars.example
@@ -27,11 +27,11 @@ rancher_server_admin_password = ""
 # docker_version = ""
 
 # Kubernetes version used for creating management server cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # rke_kubernetes_version = ""
 
 # Kubernetes version used for creating workload cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # workload_kubernetes_version = ""
 
 # Version of cert-manager to install, used in case of older Rancher versions

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -32,13 +32,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.15.3-rancher1-1"
+  default     = "v1.18.3-rancher2-2"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.16.6-rancher1-2"
+  default     = "v1.17.6-rancher2-2"
 }
 
 variable "cert_manager_version" {

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -31,13 +31,13 @@ Machine type used for all compute instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.15.3-rancher1-1"`**
+- Default: **`"v1.18.3-rancher2-2"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"1.16.6-rancher1-2"`**
+- Default: **`"v1.17.6-rancher2-2"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -49,7 +49,7 @@ Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.3.5"`**
+- Default: **`"v2.4.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/gcp/infra.tf
+++ b/gcp/infra.tf
@@ -101,7 +101,7 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = "${replace(google_compute_instance.rancher_server.network_interface.0.access_config.0.nat_ip, ".", "-")}.nip.io"
+  rancher_server_dns = join(".", ["rancher", google_compute_instance.rancher_server.network_interface.0.access_config.0.nat_ip, "xip.io"])
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -32,11 +32,11 @@ rancher_server_admin_password = ""
 # docker_version = ""
 
 # Kubernetes version used for creating management server cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # rke_kubernetes_version = ""
 
 # Kubernetes version used for creating workload cluster
-# - Must be supported by RKE terraform provider 1.0.0
+# - Must be supported by RKE terraform provider 1.0.1
 # workload_kubernetes_version = ""
 
 # Version of cert-manager to install, used in case of older Rancher versions

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -43,13 +43,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.15.3-rancher1-1"
+  default     = "v1.18.3-rancher2-2"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.16.6-rancher1-2"
+  default     = "v1.17.6-rancher2-2"
 }
 
 variable "cert_manager_version" {

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -24,7 +24,7 @@ Private key used for SSH access to the Rancher server cluster node
 Expected to be in PEM format.
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.15.3-rancher1-1"`**
+- Default: **`"v1.18.3-rancher2-2"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 ###### `cert_manager_version`
@@ -34,7 +34,7 @@ Version of cert-mananger to install alongside Rancher (format: `0.0.0`)
 Used in the case of older Rancher versions.
 
 ###### `rancher_version`
-- Default: **`"v2.3.5"`**
+- Default: **`"v2.4.5"`**
 Rancher server version (format `v0.0.0`)
 
 ###### `rancher_server_dns`
@@ -52,7 +52,7 @@ Admin password to use for Rancher server bootstrap
 Log in to the Rancher server using username `admin` and this password.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.16.6-rancher1-2"`**
+- Default: **`"v1.17.6-rancher2-2"`**
 Kubernetes version to use for managed workload cluster
 
 Defaulted to one version behind most recent minor release to allow experimenting with upgrading Kubernetes versions.

--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -5,7 +5,7 @@ provider "local" {
 
 # RKE provider - community plugin as of 2020-05-12
 provider "rke" {
-  version = "1.0.0"
+  version = "1.0.1"
 }
 
 # Kubernetes provider
@@ -42,7 +42,7 @@ provider "helm" {
 
 # Rancher2 bootstrapping provider
 provider "rancher2" {
-  version = "1.8.3"
+  version = "1.9.0"
 
   alias = "bootstrap"
 
@@ -54,7 +54,7 @@ provider "rancher2" {
 
 # Rancher2 administration provider
 provider "rancher2" {
-  version = "1.8.3"
+  version = "1.9.0"
 
   alias = "admin"
 

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -27,7 +27,7 @@ variable "ssh_private_key_pem" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.15.3-rancher1-1"
+  default     = "v1.18.3-rancher2-2"
 }
 
 variable "cert_manager_version" {
@@ -39,7 +39,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format v0.0.0)"
-  default     = "v2.4.3"
+  default     = "v2.4.5"
 }
 
 # Required
@@ -57,7 +57,7 @@ variable "admin_password" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.16.6-rancher1-2"
+  default     = "v1.17.6-rancher2-2"
 }
 
 # Required


### PR DESCRIPTION
* rke provider to 1.0.1
* Update docs to install rke provider for new release artifact structure
* rancher2 provider to 1.9.0
* rancher management cluster to 1.18.3
* workload cluster to 1.17.6
* Increase aws root disk size to prevent disk pressure related errors
* Use xip.io rancher server urls everywhere