### PR TITLE
Bump helm terraform provider to 1.2.4

### DIFF
--- a/rancher-common/data.tf
+++ b/rancher-common/data.tf
@@ -1,25 +1,5 @@
 # Data for rancher common module
 
-# Helm data
-# ----------------------------------------------------------
-
-# Jetstack Helm repository
-data "helm_repository" "jetstack" {
-  name = "jetstack"
-  url  = "https://charts.jetstack.io"
-}
-
-# Rancher Helm repository
-data "helm_repository" "rancher_stable" {
-  name = "rancher-stable"
-  url  = "https://releases.rancher.com/server-charts/stable"
-}
-
-data "helm_repository" "rancher_latest" {
-  name = "rancher-latest"
-  url  = "https://releases.rancher.com/server-charts/latest"
-}
-
 # Kubernetes data
 # ----------------------------------------------------------
 

--- a/rancher-common/helm.tf
+++ b/rancher-common/helm.tf
@@ -8,7 +8,7 @@ resource "helm_release" "cert_manager" {
     kubernetes_cluster_role_binding.cert_manager_crd_admin,
   ]
 
-  repository = data.helm_repository.jetstack.metadata[0].name
+  repository = "https://charts.jetstack.io"
   name       = "cert-manager"
   chart      = "cert-manager"
   version    = "v${var.cert_manager_version}"
@@ -21,7 +21,7 @@ resource "helm_release" "rancher_server" {
     helm_release.cert_manager,
   ]
 
-  repository = data.helm_repository.rancher_latest.metadata[0].name
+  repository = "https://releases.rancher.com/server-charts/latest"
   name       = "rancher"
   chart      = "rancher"
   version    = var.rancher_version

--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -23,11 +23,7 @@ provider "kubernetes" {
 
 # Helm provider
 provider "helm" {
-  version = "1.0.0"
-  # version = "~> 0.10"
-
-  # tiller_image    = "gcr.io/kubernetes-helm/tiller:v2.16.1"
-  # service_account = "tiller"
+  version = "1.2.4"
 
   kubernetes {
     host = rke_cluster.rancher_cluster.api_server_url


### PR DESCRIPTION
Bump helm terraform provider to 1.2.4 and remove deprecated helm_repository data sources (see https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/repository)