### PR TITLE
Update cert-manager to 0.16.0

### DIFF
--- a/rancher-common/helm.tf
+++ b/rancher-common/helm.tf
@@ -3,7 +3,6 @@
 # Install cert-manager helm chart
 resource "helm_release" "cert_manager" {
   depends_on = [
-    kubernetes_job.install_certmanager_crds,
     kubernetes_service_account.cert_manager_crd,
     kubernetes_cluster_role_binding.cert_manager_crd_admin,
   ]
@@ -13,6 +12,11 @@ resource "helm_release" "cert_manager" {
   chart      = "cert-manager"
   version    = "v${var.cert_manager_version}"
   namespace  = "cert-manager"
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
 }
 
 # Install Rancher helm chart

--- a/rancher-common/kubernetes.tf
+++ b/rancher-common/kubernetes.tf
@@ -61,30 +61,6 @@ resource "kubernetes_job" "create_cert_manager_ns" {
   }
 }
 
-# Create and run job to install cert-manager CRDs
-resource "kubernetes_job" "install_certmanager_crds" {
-  metadata {
-    name      = "install-certmanager-crds"
-    namespace = "kube-system"
-  }
-  spec {
-    template {
-      metadata {}
-      spec {
-        container {
-          name    = "hyperkube"
-          image   = "rancher/hyperkube:${local.hyperkube_tag}"
-          command = ["kubectl", "apply", "-f", "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml", "--validate=false"]
-        }
-        host_network                    = true
-        automount_service_account_token = true
-        service_account_name            = kubernetes_service_account.cert_manager_crd.metadata[0].name
-        restart_policy                  = "Never"
-      }
-    }
-  }
-}
-
 # Create cattle-system namespace for Rancher
 resource "kubernetes_job" "create_cattle_system_ns" {
   metadata {

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -33,7 +33,7 @@ variable "rke_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.16.0"
 }
 
 variable "rancher_version" {


### PR DESCRIPTION
This also simplifies the cert-manager installation a bit by installing the CRDs with the cert-manager helm chart instead of using a custom job