### PR TITLE
Updates for terraform 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,77 +38,8 @@ This setup provides easy access to the core Rancher functionality while establis
 
 ### Requirements - Cloud
 
-- Terraform >=0.12.0
-- RKE terraform provider version 1.0.1 installed locally - full install instructions [below](#installing-terraform-provider-rke)
+- Terraform >=0.13.0
 - Credentials for the cloud provider used for the quickstart
-
-#### Installing terraform-provider-rke
-
-##### Linux
-
-###### 64-bit
-
-Download [the v1.0.1 release archive for Linux](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_linux_amd64.zip),
-extract the archive, and move the binary to
-`~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.1`.
-
-If curl and unzip are installed, you can use the following script:
-```sh
-curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_linux_amd64.zip && \
-unzip terraform-provider-rke_1.0.1_linux_amd64.zip && \
-chmod +x ./terraform-provider-rke_v1.0.1 && \
-mkdir -p ~/.terraform.d/plugins/linux_amd64/ && \
-mv ./terraform-provider-rke_v1.0.1 ~/.terraform.d/plugins/linux_amd64/terraform-provider-rke_v1.0.1
-rm -rf ./terraform-provider-rke_*
-```
-
-##### MacOS
-
-Download [the v1.0.1 release archive for MacOS](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_darwin_amd64.zip),
-extract the archive, and move the binary to
-`~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.1`.
-
-If curl and unzip are installed, you can use the following script:
-```sh
-curl -LO https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_darwin_amd64.zip && \
-unzip terraform-provider-rke_1.0.1_darwin_amd64.zip && \
-chmod +x ./terraform-provider-rke_v1.0.1 && \
-mkdir -p ~/.terraform.d/plugins/darwin_amd64/ && \
-mv ./terraform-provider-rke_v1.0.1 ~/.terraform.d/plugins/darwin_amd64/terraform-provider-rke_v1.0.1
-rm -rf ./terraform-provider-rke_*
-```
-
-##### Windows
-
-###### 64-bit
-
-Download [the v1.0.1 release archive for Windows (64-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_amd64.zip),
-extract the archive, and move the executable to
-`%APPDATA%\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.1.exe`.
-
-You can use the following PowerShell script to perform the same steps (tested with PS version 5.1):
-```
-New-Item -Path $Env:APPDATA\terraform.d\plugins\windows_amd64 -ItemType Directory -Force
-Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_amd64.zip -OutFile terraform-provider-rke_1.0.1_windows_amd64.zip -UseBasicParsing
-Expand-Archive terraform-provider-rke_1.0.1_windows_amd64.zip
-Move-Item -Path terraform-provider-rke_1.0.1_windows_amd64\terraform-provider-rke_v1.0.1.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_amd64\terraform-provider-rke_v1.0.1.exe
-Remove-Item -Path terraform-provider-rke_1.0.1_windows_amd64* -Recurse
-```
-
-###### 32-bit
-
-Download [the v1.0.1 release archive for Windows (32-bit)](https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_386.zip),
-extract the archive, and move the executable to
-`%APPDATA%\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.1.exe`.
-
-You can use the following PowerShell script to perform the same steps (tested with PS version 5.1):
-```
-Invoke-WebRequest -Uri https://github.com/rancher/terraform-provider-rke/releases/download/v1.0.1/terraform-provider-rke_1.0.1_windows_386.zip -OutFile terraform-provider-rke_1.0.1_windows_386.zip -UseBasicParsing
-New-Item -Path $Env:APPDATA\terraform.d\plugins\windows_386 -ItemType Directory -Force
-Expand-Archive terraform-provider-rke_1.0.1_windows_386.zip
-Move-Item -Path terraform-provider-rke_1.0.1_windows_386\terraform-provider-rke_v1.0.1.exe -Destination $Env:APPDATA\terraform.d\plugins\windows_386\terraform-provider-rke_v1.0.1.exe
-Remove-Item -Path terraform-provider-rke_1.0.1_windows_386* -Recurse
-```
 
 ### Deploy
 

--- a/aws/provider.tf
+++ b/aws/provider.tf
@@ -1,11 +1,8 @@
 provider "aws" {
-  version = "2.41.0"
-
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
 }
 
 provider "tls" {
-  version = "2.1.1"
 }

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "3.1.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "2.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/azure-windows/infra.tf
+++ b/azure-windows/infra.tf
@@ -55,7 +55,7 @@ resource "azurerm_subnet" "rancher-quickstart-internal" {
   name                 = "rancher-quickstart-internal"
   resource_group_name  = azurerm_resource_group.rancher-quickstart.name
   virtual_network_name = azurerm_virtual_network.rancher-quickstart.name
-  address_prefix       = "10.0.0.0/16"
+  address_prefixes     = ["10.0.0.0/16"]
 }
 
 # Azure network interface for quickstart resources

--- a/azure-windows/provider.tf
+++ b/azure-windows/provider.tf
@@ -1,5 +1,4 @@
 provider "azurerm" {
-  version = "2.0.0"
   features {}
 
   subscription_id = var.azure_subscription_id
@@ -9,5 +8,4 @@ provider "azurerm" {
 }
 
 provider "tls" {
-  version = "2.1.1"
 }

--- a/azure-windows/versions.tf
+++ b/azure-windows/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "2.22.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "2.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/azure/infra.tf
+++ b/azure/infra.tf
@@ -55,7 +55,7 @@ resource "azurerm_subnet" "rancher-quickstart-internal" {
   name                 = "rancher-quickstart-internal"
   resource_group_name  = azurerm_resource_group.rancher-quickstart.name
   virtual_network_name = azurerm_virtual_network.rancher-quickstart.name
-  address_prefix       = "10.0.0.0/16"
+  address_prefixes     = ["10.0.0.0/16"]
 }
 
 # Azure network interface for quickstart resources

--- a/azure/provider.tf
+++ b/azure/provider.tf
@@ -1,5 +1,4 @@
 provider "azurerm" {
-  version = "2.0.0"
   features {}
 
   subscription_id = var.azure_subscription_id
@@ -9,5 +8,4 @@ provider "azurerm" {
 }
 
 provider "tls" {
-  version = "2.1.1"
 }

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "2.22.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "2.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/do/provider.tf
+++ b/do/provider.tf
@@ -1,8 +1,6 @@
 provider "digitalocean" {
-  version = "1.13.0"
   token   = var.do_token
 }
 
 provider "tls" {
-  version = "2.1.1"
 }

--- a/do/versions.tf
+++ b/do/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "1.22.1"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "2.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/gcp/provider.tf
+++ b/gcp/provider.tf
@@ -1,6 +1,4 @@
 provider "google" {
-  version = "3.6.0"
-
   credentials = file(var.gcp_account_json)
   project     = var.gcp_project
   region      = var.gcp_region
@@ -8,5 +6,4 @@ provider "google" {
 }
 
 provider "tls" {
-  version = "2.1.1"
 }

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "3.33.0"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = "2.2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -1,17 +1,13 @@
 # Local provider
 provider "local" {
-  version = "1.4.0"
 }
 
 # RKE provider - community plugin as of 2020-05-12
 provider "rke" {
-  version = "1.0.1"
 }
 
 # Kubernetes provider
 provider "kubernetes" {
-  version = "1.10.0"
-
   host = rke_cluster.rancher_cluster.api_server_url
 
   client_certificate     = rke_cluster.rancher_cluster.client_cert
@@ -23,8 +19,6 @@ provider "kubernetes" {
 
 # Helm provider
 provider "helm" {
-  version = "1.2.4"
-
   kubernetes {
     host = rke_cluster.rancher_cluster.api_server_url
 
@@ -38,8 +32,6 @@ provider "helm" {
 
 # Rancher2 bootstrapping provider
 provider "rancher2" {
-  version = "1.10.0"
-
   alias = "bootstrap"
 
   api_url  = "https://${var.rancher_server_dns}"
@@ -50,8 +42,6 @@ provider "rancher2" {
 
 # Rancher2 administration provider
 provider "rancher2" {
-  version = "1.10.0"
-
   alias = "admin"
 
   api_url  = "https://${var.rancher_server_dns}"

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+      version = "1.2.4"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "1.12.0"
+    }
+    local = {
+      source = "hashicorp/local"
+      version = "1.4.0"
+
+    }
+    rancher2 = {
+      source = "rancher/rancher2"
+      version = "1.10.0"
+    }
+    rke = {
+      source = "rancher/rke"
+      version = "1.0.1"
+
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
* Add required_providers blocks
* Move required provider versions to required_providers
* Bump some terraform providers to newest version
* Adapt readme

I tested that all quickstart examples still work.