### PR TITLE
Simplify cert-manager and rancher namespace creation

### DIFF
--- a/rancher-common/helm.tf
+++ b/rancher-common/helm.tf
@@ -8,11 +8,12 @@ resource "helm_release" "cert_manager" {
     kubernetes_cluster_role_binding.cert_manager_crd_admin,
   ]
 
-  repository = "https://charts.jetstack.io"
-  name       = "cert-manager"
-  chart      = "cert-manager"
-  version    = "v${var.cert_manager_version}"
-  namespace  = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  name             = "cert-manager"
+  chart            = "cert-manager"
+  version          = "v${var.cert_manager_version}"
+  namespace        = "cert-manager"
+  create_namespace = true
 }
 
 # Install Rancher helm chart
@@ -21,11 +22,12 @@ resource "helm_release" "rancher_server" {
     helm_release.cert_manager,
   ]
 
-  repository = "https://releases.rancher.com/server-charts/latest"
-  name       = "rancher"
-  chart      = "rancher"
-  version    = var.rancher_version
-  namespace  = "cattle-system"
+  repository       = "https://releases.rancher.com/server-charts/latest"
+  name             = "rancher"
+  chart            = "rancher"
+  version          = var.rancher_version
+  namespace        = "cattle-system"
+  create_namespace = true
 
   set {
     name  = "hostname"

--- a/rancher-common/kubernetes.tf
+++ b/rancher-common/kubernetes.tf
@@ -37,30 +37,6 @@ locals {
   hyperkube_tag = join("-", [local.srkv[0], local.srkv[1]])
 }
 
-# Create cert-manager namespace
-resource "kubernetes_job" "create_cert_manager_ns" {
-  metadata {
-    name      = "create-cert-manager-ns"
-    namespace = "kube-system"
-  }
-  spec {
-    template {
-      metadata {}
-      spec {
-        container {
-          name    = "hyperkube"
-          image   = "rancher/hyperkube:${local.hyperkube_tag}"
-          command = ["kubectl", "create", "namespace", "cert-manager"]
-        }
-        host_network                    = true
-        automount_service_account_token = true
-        service_account_name            = kubernetes_service_account.cert_manager_crd.metadata[0].name
-        restart_policy                  = "Never"
-      }
-    }
-  }
-}
-
 # Create and run job to install cert-manager CRDs
 resource "kubernetes_job" "install_certmanager_crds" {
   metadata {
@@ -75,30 +51,6 @@ resource "kubernetes_job" "install_certmanager_crds" {
           name    = "hyperkube"
           image   = "rancher/hyperkube:${local.hyperkube_tag}"
           command = ["kubectl", "apply", "-f", "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml", "--validate=false"]
-        }
-        host_network                    = true
-        automount_service_account_token = true
-        service_account_name            = kubernetes_service_account.cert_manager_crd.metadata[0].name
-        restart_policy                  = "Never"
-      }
-    }
-  }
-}
-
-# Create cattle-system namespace for Rancher
-resource "kubernetes_job" "create_cattle_system_ns" {
-  metadata {
-    name      = "create-cattle-system-ns"
-    namespace = "kube-system"
-  }
-  spec {
-    template {
-      metadata {}
-      spec {
-        container {
-          name    = "hyperkube"
-          image   = "rancher/hyperkube:${local.hyperkube_tag}"
-          command = ["kubectl", "create", "namespace", "cattle-system"]
         }
         host_network                    = true
         automount_service_account_token = true


### PR DESCRIPTION
Instead of deploying jobs that create the namespaces, this uses the helm create_namespace functionality. Cleanup/destroy also works without a problem.

What do you think @nikkelma?