### PR TITLE
Simplify cert-manager CRD apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: test
 test:
 	cd test/ && go test -v -timeout 45m
+
+.PHONY: fmt
+fmt:
+	terraform fmt -recursive

--- a/rancher-common/helm.tf
+++ b/rancher-common/helm.tf
@@ -3,9 +3,7 @@
 # Install cert-manager helm chart
 resource "helm_release" "cert_manager" {
   depends_on = [
-    kubernetes_job.install_certmanager_crds,
-    kubernetes_service_account.cert_manager_crd,
-    kubernetes_cluster_role_binding.cert_manager_crd_admin,
+    k8s_manifest.cert_manager_crds,
   ]
 
   repository       = "https://charts.jetstack.io"

--- a/rancher-common/kubernetes.tf
+++ b/rancher-common/kubernetes.tf
@@ -1,62 +1,9 @@
 # Kubernetes resources
 
-# Create cert-manager-crd service account
-resource "kubernetes_service_account" "cert_manager_crd" {
-  depends_on = [rke_cluster.rancher_cluster]
-
-  metadata {
-    name      = "cert-manager-crd"
-    namespace = "kube-system"
-  }
-
-  automount_service_account_token = true
+data "http" "cert_manager_crds" {
+  url = "https://raw.githubusercontent.com/jetstack/cert-manager/release-${regex("([0-9]+\\.[0-9]+)", var.cert_manager_version)[0]}/deploy/manifests/00-crds.yaml"
 }
 
-# Bind cert-manager-crd service account to cluster-admin
-resource "kubernetes_cluster_role_binding" "cert_manager_crd_admin" {
-  depends_on = [rke_cluster.rancher_cluster]
-
-  metadata {
-    name = "${kubernetes_service_account.cert_manager_crd.metadata[0].name}-admin"
-  }
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = "cluster-admin"
-  }
-  subject {
-    kind      = "ServiceAccount"
-    name      = kubernetes_service_account.cert_manager_crd.metadata[0].name
-    namespace = "kube-system"
-  }
-}
-
-locals {
-  # split_rke_kubernetes_version
-  srkv          = split("-", var.rke_kubernetes_version)
-  hyperkube_tag = join("-", [local.srkv[0], local.srkv[1]])
-}
-
-# Create and run job to install cert-manager CRDs
-resource "kubernetes_job" "install_certmanager_crds" {
-  metadata {
-    name      = "install-certmanager-crds"
-    namespace = "kube-system"
-  }
-  spec {
-    template {
-      metadata {}
-      spec {
-        container {
-          name    = "hyperkube"
-          image   = "rancher/hyperkube:${local.hyperkube_tag}"
-          command = ["kubectl", "apply", "-f", "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml", "--validate=false"]
-        }
-        host_network                    = true
-        automount_service_account_token = true
-        service_account_name            = kubernetes_service_account.cert_manager_crd.metadata[0].name
-        restart_policy                  = "Never"
-      }
-    }
-  }
+resource "k8s_manifest" "cert_manager_crds" {
+  content = data.http.cert_manager_crds.body
 }

--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -2,12 +2,16 @@
 provider "local" {
 }
 
+# HTTP provider
+provider "http" {
+}
+
 # RKE provider - community plugin as of 2020-05-12
 provider "rke" {
 }
 
 # Kubernetes provider
-provider "kubernetes" {
+provider "k8s" {
   host = rke_cluster.rancher_cluster.api_server_url
 
   client_certificate     = rke_cluster.rancher_cluster.client_cert

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -4,14 +4,17 @@ terraform {
       source  = "hashicorp/helm"
       version = "1.2.4"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "1.12.0"
+    http = {
+      source  = "hashicorp/http"
+      version = "1.2.0"
+    }
+    k8s = {
+      source  = "banzaicloud/k8s"
+      version = "0.8.2"
     }
     local = {
       source  = "hashicorp/local"
       version = "1.4.0"
-
     }
     rancher2 = {
       source  = "rancher/rancher2"


### PR DESCRIPTION
This simplifies the creation of the cert-manager CRDs by using the banzaicloud/k8s terraform provider which allows to pass any Kubernetes YAML instead of having to start a job with cluster-admin privileges.