### PR TITLE
Update cert-manager to 0.15.1

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -43,7 +43,7 @@ Kubernetes version to use for managed workload cluster
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
 
 ###### `cert_manager_version`
-- Default: **`"0.12.0"`**
+- Default: **`"0.15.1"`**
 Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 
 See `rancher-common` module variable `cert_manager_version` for more details.

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -53,7 +53,7 @@ variable "workload_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.15.1"
 }
 
 variable "rancher_version" {

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -52,7 +52,7 @@ Kubernetes version to use for managed workload cluster
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
 
 ###### `cert_manager_version`
-- Default: **`"0.12.0"`**
+- Default: **`"0.15.1"`**
 Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 
 See `rancher-common` module variable `cert_manager_version` for more details.

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -59,7 +59,7 @@ variable "workload_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.15.1"
 }
 
 variable "rancher_version" {

--- a/azure/README.md
+++ b/azure/README.md
@@ -51,7 +51,7 @@ Kubernetes version to use for managed workload cluster
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
 
 ###### `cert_manager_version`
-- Default: **`"0.12.0"`**
+- Default: **`"0.15.1"`**
 Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 
 See `rancher-common` module variable `cert_manager_version` for more details.

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -59,7 +59,7 @@ variable "workload_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.15.1"
 }
 
 variable "rancher_version" {

--- a/do/README.md
+++ b/do/README.md
@@ -38,7 +38,7 @@ Kubernetes version to use for managed workload cluster
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
 
 ###### `cert_manager_version`
-- Default: **`"0.12.0"`**
+- Default: **`"0.15.1"`**
 Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 
 See `rancher-common` module variable `cert_manager_version` for more details.

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -44,7 +44,7 @@ variable "workload_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.15.1"
 }
 
 variable "rancher_version" {

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -43,7 +43,7 @@ Kubernetes version to use for managed workload cluster
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
 
 ###### `cert_manager_version`
-- Default: **`"0.12.0"`**
+- Default: **`"0.15.1"`**
 Version of cert-mananger to install alongside Rancher (format: 0.0.0)
 
 See `rancher-common` module variable `cert_manager_version` for more details.

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -55,7 +55,7 @@ variable "workload_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.15.1"
 }
 
 variable "rancher_version" {

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -30,7 +30,7 @@ Expected to be in PEM format.
 Kubernetes version to use for Rancher server RKE cluster
 
 ###### `cert_manager_version`
-- Default: **`"0.12.0"`**
+- Default: **`"0.15.1"`**
 Version of cert-mananger to install alongside Rancher (format: `0.0.0`)
 
 Available versions are found in `files/cert-manager`, where a supported version

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -33,7 +33,7 @@ variable "rke_kubernetes_version" {
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
-  default     = "0.12.0"
+  default     = "0.15.1"
 }
 
 variable "rancher_version" {


### PR DESCRIPTION
Similar to #106 but follows the current docs recommendation of cert-manager `0.15.1`.

Depends on #113 for modified behavior of CRD installation.