### PR TITLE
Remove HTTP provider, remove mention of RKE provider as community plugin

### DIFF
--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -2,11 +2,7 @@
 provider "local" {
 }
 
-# HTTP provider
-provider "http" {
-}
-
-# RKE provider - community plugin as of 2020-05-12
+# RKE provider
 provider "rke" {
 }
 


### PR DESCRIPTION
HTTP provider was removed from required providers in #113 but associated provider declaration was not removed. Fix this small issue, and cleanup related provider comments while editing this file.