### PR TITLE
Adding support for HA, airgap, certs, etc

### DIFF
--- a/rancher-common/helm.tf
+++ b/rancher-common/helm.tf
@@ -1,8 +1,14 @@
 # Helm resources
 
+locals {
+  rancher_image_registry_secret_name = "rancher-image-registry"
+}
+
 # Install cert-manager helm chart
 resource "helm_release" "cert_manager" {
+  count = var.ingress_tls_source != "secret" ? 1 : 0
   depends_on = [
+    rke_cluster.rancher_cluster,
     k8s_manifest.cert_manager_crds,
   ]
 
@@ -17,10 +23,14 @@ resource "helm_release" "cert_manager" {
 # Install Rancher helm chart
 resource "helm_release" "rancher_server" {
   depends_on = [
+    rke_cluster.rancher_cluster,
+    kubernetes_secret.tls-rancher-ingress,
+    kubernetes_secret.tls-ca,
+    kubernetes_secret.helm_image_pull_secret,
     helm_release.cert_manager,
   ]
 
-  repository       = "https://releases.rancher.com/server-charts/latest"
+  repository       = var.rancher_helm_repository
   name             = "rancher"
   chart            = "rancher"
   version          = var.rancher_version
@@ -32,8 +42,52 @@ resource "helm_release" "rancher_server" {
     value = var.rancher_server_dns
   }
 
-  set {
-    name  = "certmanager.version"
-    value = var.cert_manager_version
+  dynamic "set" {
+    for_each = var.ingress_tls_source != "secret" ? [1] : []
+    content {
+      name  = "certmanager.version"
+      value = var.cert_manager_version
+    }
   }
+
+  dynamic "set" {
+    for_each = var.ingress_tls_source != "rancher" ? [1] : []
+    content {
+      name = "ingress.tls.source"
+      value = var.ingress_tls_source
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.system_default_registry != null ? [1] : []
+    content {
+      name  = "systemDefaultRegistry"
+      value = var.system_default_registry
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.rancher_image_registry != null ? [1] : []
+    content {
+      name = "rancherImage"
+      value = "${var.rancher_image_registry}/rancher/rancher"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.use_private_ca ? [1]: []
+    content {
+      name = "privateCA"
+      value = var.use_private_ca
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.rancher_image_registry_username != null ? [1] : []
+    content {
+      name = "imagePullSecrets[0].name"
+      value = local.rancher_image_registry_secret_name
+    }
+  }
+
 }

--- a/rancher-common/kubernetes.tf
+++ b/rancher-common/kubernetes.tf
@@ -6,6 +6,105 @@ locals {
 }
 
 resource "k8s_manifest" "cert_manager_crds" {
-  count   = length(local.cert_manager_crds_sections)
+  count   = var.ingress_tls_source != "secret" ? length(local.cert_manager_crds_sections): 0
   content = local.cert_manager_crds_sections[count.index]
+}
+
+resource "kubernetes_namespace" "cattle-system" {
+  count   = var.ingress_tls_source == "secret" ? 1 : 0
+  depends_on = [
+    rke_cluster.rancher_cluster,
+  ]
+  metadata {
+    name = "cattle-system"
+    # Need to create these dummy annotations to make ignore_changes work
+    annotations = {
+      "cattle.io/status" = "",
+      "field.cattle.io/projectId" = "",
+      "lifecycle.cattle.io/create.namespace-auth" = ""
+    }
+    # Need to create these dummy labels to make ignore_changes work
+    labels = {
+      "field.cattle.io/projectId" = ""
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations["cattle.io/status"],
+      metadata.0.annotations["lifecycle.cattle.io/create.namespace-auth"],
+      metadata.0.annotations["field.cattle.io/projectId"],
+      metadata.0.labels["field.cattle.io/projectId"]
+    ]
+  }
+}
+
+resource "kubernetes_secret" "tls-rancher-ingress" {
+  count   = var.ingress_tls_source == "secret" ? 1 : 0
+  depends_on = [
+    kubernetes_namespace.cattle-system,
+  ]
+  metadata {
+    name      = "tls-rancher-ingress"
+    namespace = "cattle-system"
+    annotations = {
+      "field.cattle.io/projectId" = ""
+    }
+  }
+  data = {
+    "tls.crt" = file(var.server_certificate)
+    "tls.key" = file(var.server_certificate_key)
+  }
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations["field.cattle.io/projectId"]
+    ]
+  }
+}
+
+resource "kubernetes_secret" "tls-ca" {
+  count = var.use_private_ca ? 1 : 0
+  depends_on = [
+    kubernetes_namespace.cattle-system,
+  ]
+  metadata {
+    name      = "tls-ca"
+    namespace = "cattle-system"
+    # Need to create these dummy annotations to make ignore_changes work
+    annotations = {
+      "field.cattle.io/projectId" = ""
+    }
+  }
+  data = {
+    "cacerts.pem" = file(var.server_private_ca_certificate)
+  }
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations["field.cattle.io/projectId"]
+    ]
+  }
+}
+
+resource "kubernetes_secret" "helm_image_pull_secret" {
+  count   = var.ingress_tls_source == "secret" ? 1 : 0
+  depends_on = [
+    kubernetes_namespace.cattle-system,
+  ]
+  metadata {
+    name      = local.rancher_image_registry_secret_name
+    namespace = "cattle-system"
+    # Need to create these dummy annotations to make ignore_changes work
+    annotations = {
+      "field.cattle.io/projectId" = ""
+    }
+  }
+  type = "Opaque"
+  data = {
+      "username" = var.rancher_image_registry_username
+      "password" = var.rancher_image_registry_password
+  }
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations["field.cattle.io/projectId"]
+    ]
+  }
 }

--- a/rancher-common/local.tf
+++ b/rancher-common/local.tf
@@ -2,11 +2,18 @@
 
 # Save kubeconfig file for interacting with the RKE cluster on your local machine
 resource "local_file" "kube_config_server_yaml" {
+  depends_on = [
+    rke_cluster.rancher_cluster,
+  ]
   filename = format("%s/%s", path.root, "kube_config_server.yaml")
   content  = rke_cluster.rancher_cluster.kube_config_yaml
 }
 
 resource "local_file" "kube_config_workload_yaml" {
+  depends_on = [
+    rancher2_cluster.quickstart_workload[0],
+  ]
+  count = var.create_workload_cluster ? 1 : 0
   filename = format("%s/%s", path.root, "kube_config_workload.yaml")
-  content  = rancher2_cluster.quickstart_workload.kube_config
+  content  = rancher2_cluster.quickstart_workload[0].kube_config
 }

--- a/rancher-common/output.tf
+++ b/rancher-common/output.tf
@@ -5,11 +5,11 @@ output "rancher_url" {
 }
 
 output "custom_cluster_command" {
-  value       = rancher2_cluster.quickstart_workload.cluster_registration_token.0.node_command
+  value       = var.create_workload_cluster ? rancher2_cluster.quickstart_workload[0].cluster_registration_token.0.node_command : null
   description = "Docker command used to add a node to the quickstart cluster"
 }
 
 output "custom_cluster_windows_command" {
-  value       = rancher2_cluster.quickstart_workload.cluster_registration_token.0.windows_node_command
+  value       = var.create_workload_cluster ?  rancher2_cluster.quickstart_workload[0].cluster_registration_token.0.windows_node_command : null
   description = "Docker command used to add a windows node to the quickstart cluster"
 }

--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -6,8 +6,19 @@ provider "local" {
 provider "rke" {
 }
 
-# Kubernetes provider
+# k8s provider
 provider "k8s" {
+  host = rke_cluster.rancher_cluster.api_server_url
+
+  client_certificate     = rke_cluster.rancher_cluster.client_cert
+  client_key             = rke_cluster.rancher_cluster.client_key
+  cluster_ca_certificate = rke_cluster.rancher_cluster.ca_crt
+
+  load_config_file = false
+}
+
+# Kubernetes provider
+provider "kubernetes" {
   host = rke_cluster.rancher_cluster.api_server_url
 
   client_certificate     = rke_cluster.rancher_cluster.client_cert

--- a/rancher-common/rancher.tf
+++ b/rancher-common/rancher.tf
@@ -14,6 +14,7 @@ resource "rancher2_bootstrap" "admin" {
 
 # Create custom managed cluster for quickstart
 resource "rancher2_cluster" "quickstart_workload" {
+  count = var.create_workload_cluster ? 1 : 0
   provider = rancher2.admin
 
   name        = var.workload_cluster_name

--- a/rancher-common/rke.tf
+++ b/rancher-common/rke.tf
@@ -4,14 +4,39 @@
 resource "rke_cluster" "rancher_cluster" {
   cluster_name = "quickstart-rancher-server"
 
-  nodes {
-    address          = var.node_public_ip
-    internal_address = var.node_internal_ip
-    user             = var.node_username
-    role             = ["controlplane", "etcd", "worker"]
-    ssh_key          = var.ssh_private_key_pem
+  dynamic nodes {
+    for_each = var.rancher_nodes == null ? [1] : []
+    content {
+      address          = var.node_public_ip
+      internal_address = var.node_internal_ip
+      user             = var.node_username
+      role             = ["controlplane", "etcd", "worker"]
+      ssh_key          = file(var.ssh_private_key_pem)
+    }
+  }
+
+  dynamic nodes {
+    for_each = var.rancher_nodes != null ? var.rancher_nodes : []
+    content {
+      address          = nodes.value.public_ip
+      internal_address = nodes.value.private_ip
+      role             = nodes.value.roles
+      user             = var.node_username
+      ssh_key          = file(var.ssh_private_key_pem)
+    }
   }
 
   kubernetes_version = var.rke_kubernetes_version
+
+  dynamic "private_registries" {
+    for_each = var.private_registry_url != null ? [1]: []
+    content {
+      url = var.private_registry_url
+      user = var.private_registry_username
+      password = var.private_registry_password
+      is_default = true
+    }
+  }
+
 }
 

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -13,6 +13,40 @@ variable "node_internal_ip" {
 }
 
 # Required
+# This variable is useful to specify multiple nodes for the rancher cluster
+# If this is not null, the previous variables node_public_ip and
+# node_internal_ip are not used.
+#
+# Example:
+# default = [
+#   {
+#     public_ip = "1.1.1.1",
+#     private_ip = "1.1.1.1",
+#     roles = ["etcd", "controlplane", "worker"]
+#   },
+#   {
+#     public_ip = "2.2.2.2",
+#     private_ip = "2.2.2.2",
+#     roles = ["etcd", "controlplane", "worker"]
+#   },
+#   {
+#     public_ip = "3.3.3.3",
+#     private_ip = "3.3.3.3",
+#     roles = ["etcd", "controlplane", "worker"]
+#   }
+# ]
+#
+variable "rancher_nodes" {
+  type = list(object({
+    public_ip = string
+    private_ip = string
+    roles = list(string)
+  }))
+  default = null
+  description = "List of compute nodes for Rancher cluster"
+}
+
+# Required
 variable "node_username" {
   type        = string
   description = "Username used for SSH access to the Rancher server cluster node"
@@ -21,7 +55,7 @@ variable "node_username" {
 # Required
 variable "ssh_private_key_pem" {
   type        = string
-  description = "Private key used for SSH access to the Rancher server cluster node"
+  description = "Private key used for SSH access to the Rancher server cluster node(s)"
 }
 
 variable "rke_kubernetes_version" {
@@ -30,9 +64,50 @@ variable "rke_kubernetes_version" {
   default     = "v1.18.8-rancher1-1"
 }
 
+variable ingress_tls_source {
+  type        = string
+  description = "Specify the source of TLS certificates. Valid options: rancher, letsEncrypt, secret"
+  default     = "rancher"
+}
+
+# This option is relevant only if ingress_tls_source is set to "letsEncrypt"
+variable lets_encrypt_email {
+  type        = string
+  description = "Email address used for communication about your certificate (for example, expiry notices)"
+  default     = null
+}
+
+# This option is relevant only if ingress_tls_source is set to "secret"
+variable server_certificate {
+  type        = string
+  description = "Specify the location of the server certificate file (public). Ex: /home/ubuntu/tls.crt"
+  default     = null
+}
+
+# This option is relevant only if ingress_tls_source is set to "secret"
+variable server_certificate_key {
+  type        = string
+  description = "Specify the location of the server certificate private key file. Ex: /home/ubuntu/tls.key"
+  default     = null
+}
+
+# This option is relevant only if ingress_tls_source is set to "secret" and if private CA is used
+variable use_private_ca {
+  type        = bool
+  description = "Specify if private CA signed certificates are used"
+  default     = false
+}
+
+variable server_private_ca_certificate {
+  type        = string
+  description = "Specify the location of the private CA certificate file. Ex: /home/ubuntu/ca.crt"
+  default     = null
+}
+
+# This variable is used only if ingress_tls_source is set to either "rancher" or "letsEncrypt
 variable "cert_manager_version" {
   type        = string
-  description = "Version of cert-mananger to install alongside Rancher (format: 0.0.0)"
+  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
   default     = "0.15.1"
 }
 
@@ -42,16 +117,74 @@ variable "rancher_version" {
   default     = "v2.4.8"
 }
 
+variable "system_default_registry" {
+  type        = string
+  description = "Specify the default registry for various RKE images. Ex: artifactory.company.com/docker"
+  default     = null
+}
+
+variable "rancher_image_registry" {
+  type        = string
+  description = "Specify the registry of rancher image. Ex: artifactory.company.com/docker"
+  default     = null
+}
+
+variable "rancher_image_registry_username" {
+  type        = string
+  description = "Specify rancher image registry's username"
+  default     = null
+}
+
+variable "rancher_image_registry_password" {
+  type        = string
+  description = "Specify rancher image registry's password"
+  default     = null
+}
+
+variable "private_registry_url" {
+  type        = string
+  description = "Specify the private registry where kubernetes images are hosted. Ex: artifactory.company.com/docker"
+  default     = null
+}
+
+variable "private_registry_username" {
+  type        = string
+  description = "Specify private registry's username"
+  default     = null
+}
+
+variable "private_registry_password" {
+  type        = string
+  description = "Specify private registry's password"
+  default     = null
+}
+
 # Required
 variable "rancher_server_dns" {
   type        = string
-  description = "DNS host name of the Rancher server"
+  description = "DNS host name of the Rancher server. Ex: rancher.mycompany.com"
+}
+
+variable "rancher_helm_repository" {
+  type        = string
+  description = "Specify the URL where Rancher Helm Repository is hosted"
+  default     = "https://releases.rancher.com/server-charts/latest"
 }
 
 # Required
 variable "admin_password" {
   type        = string
   description = "Admin password to use for Rancher server bootstrap"
+}
+
+# A Custom Workload/Downstream cluster is created with the following
+# configuration options. Nodes can later be added to this cluster
+# to this cluster by using the `docker run` bootstrap command provided
+# in the cluster page of Rancher UI.
+variable "create_workload_cluster" {
+  type        = bool
+  description = "Specify if workload cluster needs to be created after completion of Rancher Server installation"
+  default     = true
 }
 
 variable "workload_kubernetes_version" {


### PR DESCRIPTION
- Multiple nodes can be specified with varying roles
- Support for private registries
- Support for private helm repo for rancher chart
- SSL certs support, along with private CA ability
- Only relevant resources are created using conditional/dynamic blocks