### PR TITLE
Pin quickstart/vagrant Rancher version

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
       end
       server.vm.network x.fetch('net').fetch('network_type'), ip: x.fetch('ip').fetch('server') , nic_type: $private_nic_type
       server.vm.hostname = "server-01"
-      server.vm.provision "shell", path: "scripts/configure_rancher_server.sh", args: [x.fetch('admin_password'), x.fetch('version'), x.fetch('k8s_version')]
+      server.vm.provision "shell", path: "scripts/configure_rancher_server.sh", args: [x.fetch('admin_password'), x.fetch('rancher_version'), x.fetch('k8s_version')]
     
   end
 

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,5 +1,5 @@
 admin_password: admin
-version: latest
+version: v2.4.8
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available
 k8s_version: ""

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,5 +1,5 @@
 admin_password: admin
-version: v2.4.8
+rancher_version: v2.4.8
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available
 k8s_version: ""

--- a/vagrant/scripts/configure_rancher_server.sh
+++ b/vagrant/scripts/configure_rancher_server.sh
@@ -2,7 +2,7 @@
 
 rancher_ip="172.22.101.101"
 admin_password=${1:-password}
-rancher_version=${2:-latest}
+rancher_version=${2:-stable}
 k8s_version=$3
 curlimage="appropriate/curl"
 jqimage="stedolan/jq"


### PR DESCRIPTION
I experienced: https://github.com/rancher/quickstart/issues/129

But after applying that workaround it looked like there was other changes potentially required for 2.5 and I noticed that https://github.com/rancher/quickstart/commit/e7f8e6cbb9bdbd9900294554b03c0432cb925634 pinned the versions for the other providers.

I think pinning the version of Rancher is good idea for future stability to prevent silent regressions after new Rancher releases.