### PR TITLE
Fix quickstart/vagrant readme description

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,6 +1,6 @@
 # Vagrant Quickstart
 
-This folder contains Vagrant code to stand up a single Rancher server instance with a 3 node cluster attached to it.
+This folder contains Vagrant code to stand up a single Rancher server instance with a single node cluster attached to it.
 
 ## Requirements
 


### PR DESCRIPTION
- Vagrant quickstart starts a single node cluster, not a 3 node cluster