### PR TITLE
Bump all terraform provider versions

### DIFF
--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -2,14 +2,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.1.0"
+      version = "3.12.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = "2.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "2.2.0"
+      version = "3.0.0"
     }
   }
   required_version = ">= 0.13"

--- a/azure-windows/versions.tf
+++ b/azure-windows/versions.tf
@@ -2,14 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.22.0"
+      version = "2.33.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = "2.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "2.2.0"
+      version = "3.0.0"
     }
   }
   required_version = ">= 0.13"

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -2,14 +2,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.22.0"
+      version = "2.33.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = "2.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "2.2.0"
+      version = "3.0.0"
     }
   }
   required_version = ">= 0.13"

--- a/do/versions.tf
+++ b/do/versions.tf
@@ -2,14 +2,15 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "1.22.1"
+      version = "2.0.1"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = "2.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "2.2.0"
+      version = "3.0.0"
     }
   }
   required_version = ">= 0.13"

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -2,14 +2,15 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "3.33.0"
+      version = "3.44.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = "2.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "2.2.0"
+      version = "3.0.0"
     }
   }
   required_version = ">= 0.13"

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -2,23 +2,23 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "1.2.4"
+      version = "1.3.2"
     }
     k8s = {
       source  = "banzaicloud/k8s"
-      version = "0.8.2"
+      version = "0.8.3"
     }
     local = {
       source  = "hashicorp/local"
-      version = "1.4.0"
+      version = "2.0.0"
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = "1.10.2"
+      version = "1.10.3"
     }
     rke = {
       source  = "rancher/rke"
-      version = "1.1.2"
+      version = "1.1.3"
     }
   }
   required_version = ">= 0.13"

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     k8s = {
       source  = "banzaicloud/k8s"
-      version = "0.8.3"
+      version = "0.8.2"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
`banzaicloud/k8s` held back due to using anti-pattern of configuring a provider with interpolated parameters that are created in the same `apply` command, covered by #81.