### PR TITLE
Limit Azure computer_name field length

### DIFF
--- a/azure-windows/infra.tf
+++ b/azure-windows/infra.tf
@@ -76,9 +76,16 @@ resource "azurerm_network_interface" "rancher-server-interface" {
   }
 }
 
+// ensure computer_name meets 15 character limit
+// uses assumption that resources only use 4 characters for a suffix
+locals {
+  computer_name_prefix = substr(var.prefix, 0, 11)
+}
+
 # Azure linux virtual machine for creating a single node RKE cluster and installing the Rancher Server
 resource "azurerm_linux_virtual_machine" "rancher_server" {
   name                  = "${var.prefix}-rancher-win-server"
+  computer_name         = "${local.computer_name_prefix}-rws" // ensure computer_name meets 15 character limit
   location              = azurerm_resource_group.rancher-quickstart.location
   resource_group_name   = azurerm_resource_group.rancher-quickstart.name
   network_interface_ids = [azurerm_network_interface.rancher-server-interface.id]
@@ -193,7 +200,8 @@ resource "azurerm_network_interface" "quickstart-node-interface" {
 
 # Azure linux virtual machine for creating for the workload cluster
 resource "azurerm_linux_virtual_machine" "quickstart-node" {
-  name                  = "${var.prefix}-quickstart-win-node"
+  name                  = "${var.prefix}-quickstart-win-node-master"
+  computer_name         = "${local.computer_name_prefix}-qm" // ensure computer_name meets 15 character limit
   location              = azurerm_resource_group.rancher-quickstart.location
   resource_group_name   = azurerm_resource_group.rancher-quickstart.name
   network_interface_ids = [azurerm_network_interface.quickstart-node-interface.id]
@@ -280,7 +288,8 @@ resource "azurerm_network_interface" "quickstart-windows-node-interface" {
 
 # Azure windows virtual machine for joining the workload cluster
 resource "azurerm_windows_virtual_machine" "quickstart-windows-node" {
-  name                  = "${var.prefix}-win"
+  name                  = "${var.prefix}-quickstart-win-node-worker"
+  computer_name         = "${local.computer_name_prefix}-qw" // ensure computer_name meets 15 character limit
   location              = azurerm_resource_group.rancher-quickstart.location
   resource_group_name   = azurerm_resource_group.rancher-quickstart.name
   network_interface_ids = [azurerm_network_interface.quickstart-windows-node-interface.id]

--- a/azure/infra.tf
+++ b/azure/infra.tf
@@ -76,9 +76,16 @@ resource "azurerm_network_interface" "rancher-server-interface" {
   }
 }
 
+// ensure computer_name meets 15 character limit
+// uses assumption that resources only use 4 characters for a suffix
+locals {
+  computer_name_prefix = substr(var.prefix, 0, 11)
+}
+
 # Azure linux virtual machine for creating a single node RKE cluster and installing the Rancher Server
 resource "azurerm_linux_virtual_machine" "rancher_server" {
   name                  = "${var.prefix}-rancher-server"
+  computer_name         = "${local.computer_name_prefix}-rs" // ensure computer_name meets 15 character limit
   location              = azurerm_resource_group.rancher-quickstart.location
   resource_group_name   = azurerm_resource_group.rancher-quickstart.name
   network_interface_ids = [azurerm_network_interface.rancher-server-interface.id]
@@ -186,6 +193,7 @@ resource "azurerm_network_interface" "quickstart-node-interface" {
 # Azure linux virtual machine for creating a single node RKE cluster and installing the Rancher Server
 resource "azurerm_linux_virtual_machine" "quickstart-node" {
   name                  = "${var.prefix}-quickstart-node"
+  computer_name         = "${local.computer_name_prefix}-qn" // ensure computer_name meets 15 character limit
   location              = azurerm_resource_group.rancher-quickstart.location
   resource_group_name   = azurerm_resource_group.rancher-quickstart.name
   network_interface_ids = [azurerm_network_interface.quickstart-node-interface.id]

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -37,7 +37,7 @@ func TestE2E_Gcp(t *testing.T) {
 func runTerraformAndVerify(t *testing.T, terraformDir string) {
 	t.Parallel()
 
-	prefix := "qs-test-" + rand.String(7)
+	prefix := "qs-" + rand.String(5) + "-test"
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: terraformDir,


### PR DESCRIPTION
Azure `*_virtual_machine` resources in `azure-windows` encountered errors during tests where `computer_name` was over the 15 character limit. Enforce these limits in terraform resources, reformat test prefix to maintain randomness despite end characters being trimmed.