### PR TITLE
Update Rancher to 2.5.3

### DIFF
--- a/aws/.terraform.lock.hcl
+++ b/aws/.terraform.lock.hcl
@@ -1,0 +1,126 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/banzaicloud/k8s" {
+  version     = "0.8.2"
+  constraints = "0.8.2"
+  hashes = [
+    "h1:kz2tBOpjc1nAonsB7LivtLTknStLZOu8cJO+/S6ws/4=",
+    "zh:0c35fc49c921ae981c29222a199cab012826f1ef2bbbe7c92741abad18d0f36a",
+    "zh:334e72d8b8d3d94cceb7a1ba6acbfbafde100e0714e58ebc759692e3e0a7ce19",
+    "zh:4ca36e8a85ee5bf0fe86f1f741423b164a2171fc9e53d3f913fe6b3739256ed6",
+    "zh:5b1b49dfcd560fadb392d4328fc5f66a17b6d9dd56816de4960df50cbf6b25d0",
+    "zh:95ee0507821e02f969067b835d629d2da474617177c0f8bee09c524967f19636",
+    "zh:977e10f1bc4228634d42c3d2b01c50850e411b1c7283109ff6046fcdb0a17987",
+    "zh:addccf62780281388e98acaf481ef2e296e46d3abd0130ac48876ecfef94d482",
+    "zh:bcfeae859dd9dbafabfab5fb89b13f523f82e92e3e105d01cb8566e16451d609",
+    "zh:ce796318e24c17cb6c40bd109bf15329e6e475eecc262660c1de9b5856c248ae",
+    "zh:d3ae0e6efad223f0857afca8e09ad40ac6c9e2b454b32705d4a785a3a8f5fe37",
+    "zh:e00f1c5d7c7c37d12791e7ad2ce58bbcec84f1c304aa7485be34355e7523f1db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.12.0"
+  constraints = "3.12.0"
+  hashes = [
+    "h1:3gkfYjOVSHc3g/eXnk/JnRuoYtoDRu1oV3YPmBnuVtY=",
+    "zh:002f7c17f927978e06c5c6ff7dd3f4600f0ab7ec7e43e62eedfce2b22c70b009",
+    "zh:0400f415121efad618d9ddca71522eb4d0958905e705daa6ecd9f7d8c1330253",
+    "zh:285e630188f7d0fd3d1e6f715326723904f02a2fa571e40dde36ae1b5cd5542e",
+    "zh:402140c0a7d0423ff7c49b6bd03769332b8beb41838bf58eb83b7cfa73f67e09",
+    "zh:7506eadb178fa41c02a0127e06ab4a49f2604860f0992f7c4f519993932d2a41",
+    "zh:95dffd98bad81a2288953f36250f358ab9560d6bfb249ff5d00bf4f3131cc08b",
+    "zh:aa530b43e4a2ff89025d8b4ed2384b67cadedbf84c67ee903bac133376d929b9",
+    "zh:b2314b788a6a7091f4d70bff3825077e06c9c994b1efe76ad5f0e4b60944e60b",
+    "zh:b68d3df21d7d67641e08476bd456d04bd33d963caba41024a14dddd85b0bde10",
+    "zh:b9a8204ce6ab4929145cd2a284ba89790813692c6de9c8e12be9c1d984989180",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "1.3.2"
+  constraints = "1.3.2"
+  hashes = [
+    "h1:l8zW5Bw3Q4RbNbqyS6SIGKN0KG9WKQFo9gnhxfYV2W8=",
+    "zh:0d8e1293cb99b61d3aefbab3f1c1e258e121d860312115e23b240e8acb92b855",
+    "zh:17524fac3f1eb46901a27ecef0c054c8b5390994b2f0bd48746a5eb47e42fad5",
+    "zh:74ff2d471fc934d0e65452f914248c23394937a9b4cfb560ce920d5c42568303",
+    "zh:855255f4afe7b86d88744f5615b6b6a6172fa7fc28c24d8fb5838b715e3b8a97",
+    "zh:8b3bb0f0e2e6908c3d41ee183451cb388a80cf576b0953ad3d1e06cb4de22842",
+    "zh:b46d607cedfefc94460bbff8a9d46e50f7dce364dc4050a2df81357159e07f81",
+    "zh:c9b9f3b0e6aaec7081230df257f89e00e522a3a283197126d88ae646551cde6e",
+    "zh:ccb0b341351df79773367aa6d895b89647ceb9a75fff1c434ee480513515d112",
+    "zh:e39f56174f61556f2937fe50035703346833555cb83f2a880e3a4d832262120e",
+    "zh:f792f8b620551198807bed0752453ff0574b1b7b03ec9d9a580177b84049c700",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.0.0"
+  constraints = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "1.10.6"
+  constraints = "1.10.6"
+  hashes = [
+    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
+    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
+    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
+    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
+    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
+    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
+    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
+    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
+    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
+    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
+    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
+    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rke" {
+  version     = "1.1.6"
+  constraints = "1.1.6"
+  hashes = [
+    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
+    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
+    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
+    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
+    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
+    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
+    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+  ]
+}

--- a/aws/README.md
+++ b/aws/README.md
@@ -37,7 +37,7 @@ Kubernetes version to use for Rancher server RKE cluster
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.10-rancher1-2"`**
+- Default: **`"v1.18.12-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.

--- a/aws/README.md
+++ b/aws/README.md
@@ -31,7 +31,7 @@ Instance type used for all EC2 instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.3-rancher1-2"`**
+- Default: **`"v1.19.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.

--- a/aws/README.md
+++ b/aws/README.md
@@ -49,7 +49,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.2"`**
+- Default: **`"v2.5.3"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -41,7 +41,7 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.3-rancher1-2"
+  default     = "v1.19.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -47,7 +47,7 @@ variable "rke_kubernetes_version" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.10-rancher1-2"
+  default     = "v1.18.12-rancher1-1"
 }
 
 variable "cert_manager_version" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -59,7 +59,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.2"
+  default     = "v2.5.3"
 }
 
 # Required

--- a/azure-windows/.terraform.lock.hcl
+++ b/azure-windows/.terraform.lock.hcl
@@ -1,0 +1,126 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/banzaicloud/k8s" {
+  version     = "0.8.2"
+  constraints = "0.8.2"
+  hashes = [
+    "h1:kz2tBOpjc1nAonsB7LivtLTknStLZOu8cJO+/S6ws/4=",
+    "zh:0c35fc49c921ae981c29222a199cab012826f1ef2bbbe7c92741abad18d0f36a",
+    "zh:334e72d8b8d3d94cceb7a1ba6acbfbafde100e0714e58ebc759692e3e0a7ce19",
+    "zh:4ca36e8a85ee5bf0fe86f1f741423b164a2171fc9e53d3f913fe6b3739256ed6",
+    "zh:5b1b49dfcd560fadb392d4328fc5f66a17b6d9dd56816de4960df50cbf6b25d0",
+    "zh:95ee0507821e02f969067b835d629d2da474617177c0f8bee09c524967f19636",
+    "zh:977e10f1bc4228634d42c3d2b01c50850e411b1c7283109ff6046fcdb0a17987",
+    "zh:addccf62780281388e98acaf481ef2e296e46d3abd0130ac48876ecfef94d482",
+    "zh:bcfeae859dd9dbafabfab5fb89b13f523f82e92e3e105d01cb8566e16451d609",
+    "zh:ce796318e24c17cb6c40bd109bf15329e6e475eecc262660c1de9b5856c248ae",
+    "zh:d3ae0e6efad223f0857afca8e09ad40ac6c9e2b454b32705d4a785a3a8f5fe37",
+    "zh:e00f1c5d7c7c37d12791e7ad2ce58bbcec84f1c304aa7485be34355e7523f1db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.33.0"
+  constraints = "2.33.0"
+  hashes = [
+    "h1:50SFV/hnU3PK3UW0It64yAWjwfODE8IQIxFg1K9oaSk=",
+    "zh:0875f3f5cdaca99abce0568b93f2db713cc2e167713f0beee79168ac46dbccd2",
+    "zh:2ba58d32ff71bc5a6198672d5e703d3582cc55c3807148dc4d860ebb9bb303db",
+    "zh:34a739cb4d5d85945f1b9c44310f1f58cc848c50ce25ce591bfc622fc00e1519",
+    "zh:66acf98ee6c5efdb097bd29f423439744cde29b764539165042651fe1898ac80",
+    "zh:739d95dac30bc39650a8bd3cc5e409b892f14fbf2badeabec74e0b51d9a341c5",
+    "zh:7d52a1c83bc1a1a61bc9467136752c06d78317998a21be801e07419857f5e7f2",
+    "zh:a9239b9825dd642019c393ad996ce21a79bce76c534231804844a9abfefeeecd",
+    "zh:b4f85474bcb0e3c8be9f5af5ed21836da554d85bfb88ba9f0a4e4105cc938bff",
+    "zh:d6fc5fc635de2538c1942239298d093187c003ae8227bcf4241b47c63244c303",
+    "zh:eb3f7702c18e51d6e6c3983cff95e889540c2eb9eacf88c8ced4f2e55e6694ce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "1.3.2"
+  constraints = "1.3.2"
+  hashes = [
+    "h1:l8zW5Bw3Q4RbNbqyS6SIGKN0KG9WKQFo9gnhxfYV2W8=",
+    "zh:0d8e1293cb99b61d3aefbab3f1c1e258e121d860312115e23b240e8acb92b855",
+    "zh:17524fac3f1eb46901a27ecef0c054c8b5390994b2f0bd48746a5eb47e42fad5",
+    "zh:74ff2d471fc934d0e65452f914248c23394937a9b4cfb560ce920d5c42568303",
+    "zh:855255f4afe7b86d88744f5615b6b6a6172fa7fc28c24d8fb5838b715e3b8a97",
+    "zh:8b3bb0f0e2e6908c3d41ee183451cb388a80cf576b0953ad3d1e06cb4de22842",
+    "zh:b46d607cedfefc94460bbff8a9d46e50f7dce364dc4050a2df81357159e07f81",
+    "zh:c9b9f3b0e6aaec7081230df257f89e00e522a3a283197126d88ae646551cde6e",
+    "zh:ccb0b341351df79773367aa6d895b89647ceb9a75fff1c434ee480513515d112",
+    "zh:e39f56174f61556f2937fe50035703346833555cb83f2a880e3a4d832262120e",
+    "zh:f792f8b620551198807bed0752453ff0574b1b7b03ec9d9a580177b84049c700",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.0.0"
+  constraints = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "1.10.6"
+  constraints = "1.10.6"
+  hashes = [
+    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
+    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
+    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
+    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
+    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
+    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
+    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
+    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
+    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
+    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
+    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
+    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rke" {
+  version     = "1.1.6"
+  constraints = "1.1.6"
+  hashes = [
+    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
+    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
+    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
+    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
+    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
+    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
+    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+  ]
+}

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -40,7 +40,7 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.3-rancher1-2"`**
+- Default: **`"v1.19.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -58,7 +58,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.2"`**
+- Default: **`"v2.5.3"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -46,7 +46,7 @@ Kubernetes version to use for Rancher server RKE cluster
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.10-rancher1-2"`**
+- Default: **`"v1.18.12-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -47,7 +47,7 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.3-rancher1-2"
+  default     = "v1.19.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -53,7 +53,7 @@ variable "rke_kubernetes_version" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.10-rancher1-2"
+  default     = "v1.18.12-rancher1-1"
 }
 
 variable "cert_manager_version" {

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -65,7 +65,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.2"
+  default     = "v2.5.3"
 }
 
 # Required

--- a/azure/.terraform.lock.hcl
+++ b/azure/.terraform.lock.hcl
@@ -1,0 +1,126 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/banzaicloud/k8s" {
+  version     = "0.8.2"
+  constraints = "0.8.2"
+  hashes = [
+    "h1:kz2tBOpjc1nAonsB7LivtLTknStLZOu8cJO+/S6ws/4=",
+    "zh:0c35fc49c921ae981c29222a199cab012826f1ef2bbbe7c92741abad18d0f36a",
+    "zh:334e72d8b8d3d94cceb7a1ba6acbfbafde100e0714e58ebc759692e3e0a7ce19",
+    "zh:4ca36e8a85ee5bf0fe86f1f741423b164a2171fc9e53d3f913fe6b3739256ed6",
+    "zh:5b1b49dfcd560fadb392d4328fc5f66a17b6d9dd56816de4960df50cbf6b25d0",
+    "zh:95ee0507821e02f969067b835d629d2da474617177c0f8bee09c524967f19636",
+    "zh:977e10f1bc4228634d42c3d2b01c50850e411b1c7283109ff6046fcdb0a17987",
+    "zh:addccf62780281388e98acaf481ef2e296e46d3abd0130ac48876ecfef94d482",
+    "zh:bcfeae859dd9dbafabfab5fb89b13f523f82e92e3e105d01cb8566e16451d609",
+    "zh:ce796318e24c17cb6c40bd109bf15329e6e475eecc262660c1de9b5856c248ae",
+    "zh:d3ae0e6efad223f0857afca8e09ad40ac6c9e2b454b32705d4a785a3a8f5fe37",
+    "zh:e00f1c5d7c7c37d12791e7ad2ce58bbcec84f1c304aa7485be34355e7523f1db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.33.0"
+  constraints = "2.33.0"
+  hashes = [
+    "h1:50SFV/hnU3PK3UW0It64yAWjwfODE8IQIxFg1K9oaSk=",
+    "zh:0875f3f5cdaca99abce0568b93f2db713cc2e167713f0beee79168ac46dbccd2",
+    "zh:2ba58d32ff71bc5a6198672d5e703d3582cc55c3807148dc4d860ebb9bb303db",
+    "zh:34a739cb4d5d85945f1b9c44310f1f58cc848c50ce25ce591bfc622fc00e1519",
+    "zh:66acf98ee6c5efdb097bd29f423439744cde29b764539165042651fe1898ac80",
+    "zh:739d95dac30bc39650a8bd3cc5e409b892f14fbf2badeabec74e0b51d9a341c5",
+    "zh:7d52a1c83bc1a1a61bc9467136752c06d78317998a21be801e07419857f5e7f2",
+    "zh:a9239b9825dd642019c393ad996ce21a79bce76c534231804844a9abfefeeecd",
+    "zh:b4f85474bcb0e3c8be9f5af5ed21836da554d85bfb88ba9f0a4e4105cc938bff",
+    "zh:d6fc5fc635de2538c1942239298d093187c003ae8227bcf4241b47c63244c303",
+    "zh:eb3f7702c18e51d6e6c3983cff95e889540c2eb9eacf88c8ced4f2e55e6694ce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "1.3.2"
+  constraints = "1.3.2"
+  hashes = [
+    "h1:l8zW5Bw3Q4RbNbqyS6SIGKN0KG9WKQFo9gnhxfYV2W8=",
+    "zh:0d8e1293cb99b61d3aefbab3f1c1e258e121d860312115e23b240e8acb92b855",
+    "zh:17524fac3f1eb46901a27ecef0c054c8b5390994b2f0bd48746a5eb47e42fad5",
+    "zh:74ff2d471fc934d0e65452f914248c23394937a9b4cfb560ce920d5c42568303",
+    "zh:855255f4afe7b86d88744f5615b6b6a6172fa7fc28c24d8fb5838b715e3b8a97",
+    "zh:8b3bb0f0e2e6908c3d41ee183451cb388a80cf576b0953ad3d1e06cb4de22842",
+    "zh:b46d607cedfefc94460bbff8a9d46e50f7dce364dc4050a2df81357159e07f81",
+    "zh:c9b9f3b0e6aaec7081230df257f89e00e522a3a283197126d88ae646551cde6e",
+    "zh:ccb0b341351df79773367aa6d895b89647ceb9a75fff1c434ee480513515d112",
+    "zh:e39f56174f61556f2937fe50035703346833555cb83f2a880e3a4d832262120e",
+    "zh:f792f8b620551198807bed0752453ff0574b1b7b03ec9d9a580177b84049c700",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.0.0"
+  constraints = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "1.10.6"
+  constraints = "1.10.6"
+  hashes = [
+    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
+    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
+    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
+    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
+    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
+    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
+    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
+    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
+    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
+    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
+    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
+    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rke" {
+  version     = "1.1.6"
+  constraints = "1.1.6"
+  hashes = [
+    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
+    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
+    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
+    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
+    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
+    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
+    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+  ]
+}

--- a/azure/README.md
+++ b/azure/README.md
@@ -45,7 +45,7 @@ Kubernetes version to use for Rancher server RKE cluster
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.10-rancher1-2"`**
+- Default: **`"v1.18.12-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.

--- a/azure/README.md
+++ b/azure/README.md
@@ -57,7 +57,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.2"`**
+- Default: **`"v2.5.3"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure/README.md
+++ b/azure/README.md
@@ -39,7 +39,7 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.3-rancher1-2"`**
+- Default: **`"v1.19.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -47,7 +47,7 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.3-rancher1-2"
+  default     = "v1.19.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -53,7 +53,7 @@ variable "rke_kubernetes_version" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.10-rancher1-2"
+  default     = "v1.18.12-rancher1-1"
 }
 
 variable "cert_manager_version" {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -65,7 +65,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.2"
+  default     = "v2.5.3"
 }
 
 # Required

--- a/do/.terraform.lock.hcl
+++ b/do/.terraform.lock.hcl
@@ -1,0 +1,127 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/banzaicloud/k8s" {
+  version     = "0.8.2"
+  constraints = "0.8.2"
+  hashes = [
+    "h1:kz2tBOpjc1nAonsB7LivtLTknStLZOu8cJO+/S6ws/4=",
+    "zh:0c35fc49c921ae981c29222a199cab012826f1ef2bbbe7c92741abad18d0f36a",
+    "zh:334e72d8b8d3d94cceb7a1ba6acbfbafde100e0714e58ebc759692e3e0a7ce19",
+    "zh:4ca36e8a85ee5bf0fe86f1f741423b164a2171fc9e53d3f913fe6b3739256ed6",
+    "zh:5b1b49dfcd560fadb392d4328fc5f66a17b6d9dd56816de4960df50cbf6b25d0",
+    "zh:95ee0507821e02f969067b835d629d2da474617177c0f8bee09c524967f19636",
+    "zh:977e10f1bc4228634d42c3d2b01c50850e411b1c7283109ff6046fcdb0a17987",
+    "zh:addccf62780281388e98acaf481ef2e296e46d3abd0130ac48876ecfef94d482",
+    "zh:bcfeae859dd9dbafabfab5fb89b13f523f82e92e3e105d01cb8566e16451d609",
+    "zh:ce796318e24c17cb6c40bd109bf15329e6e475eecc262660c1de9b5856c248ae",
+    "zh:d3ae0e6efad223f0857afca8e09ad40ac6c9e2b454b32705d4a785a3a8f5fe37",
+    "zh:e00f1c5d7c7c37d12791e7ad2ce58bbcec84f1c304aa7485be34355e7523f1db",
+  ]
+}
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.0.1"
+  constraints = "2.0.1"
+  hashes = [
+    "h1:9aKwsWywDNLNH6HFF/NEvjmiUkNhDVqbCYzps3Sqieo=",
+    "zh:0fef5a287a4ce61eab2a719f5e50e61bd0ee85417fe8127e443ecf20baa3b50e",
+    "zh:3a10810ac142d69e0d2caddfa394bbdfd809190afee32d9046eb22dba4228880",
+    "zh:4eea0316695b1524eb1b9ec76dfa97967228232f73f2c2991a468a1c313a9ca3",
+    "zh:5c979231ae9f569a97c3d650ffe446b4eb541ecfa35fd57fd63fad89d9bb3c64",
+    "zh:6a531579daeae3b32d0f065a54fb452b8fcc2f5f20f5dac109b1ea285cf34285",
+    "zh:7930a03127b4eb6b7834457389866b35e13b74f7df08a6208e218ac628524eeb",
+    "zh:9a17e261d63fe898a91bb31378e1756712610e9da9fbeffb79da4b1849b02d62",
+    "zh:9d6e9e0223bb8de2151973e7ba49a9515dd705292688dafed02d6bedcc803a6b",
+    "zh:c00b2fd331978d21cbfcd04dc37a01277f4fe2b77520b4ea543609cf97a423e9",
+    "zh:cc02c6b5d6390cc4b404048eb11749ef460cc1f7d89b9b49b62dde3f2d06121a",
+    "zh:e6ba39282176b544a22d7bf8f243e44ea141fc71e8492b4423fd4f780cc0e028",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "1.3.2"
+  constraints = "1.3.2"
+  hashes = [
+    "h1:l8zW5Bw3Q4RbNbqyS6SIGKN0KG9WKQFo9gnhxfYV2W8=",
+    "zh:0d8e1293cb99b61d3aefbab3f1c1e258e121d860312115e23b240e8acb92b855",
+    "zh:17524fac3f1eb46901a27ecef0c054c8b5390994b2f0bd48746a5eb47e42fad5",
+    "zh:74ff2d471fc934d0e65452f914248c23394937a9b4cfb560ce920d5c42568303",
+    "zh:855255f4afe7b86d88744f5615b6b6a6172fa7fc28c24d8fb5838b715e3b8a97",
+    "zh:8b3bb0f0e2e6908c3d41ee183451cb388a80cf576b0953ad3d1e06cb4de22842",
+    "zh:b46d607cedfefc94460bbff8a9d46e50f7dce364dc4050a2df81357159e07f81",
+    "zh:c9b9f3b0e6aaec7081230df257f89e00e522a3a283197126d88ae646551cde6e",
+    "zh:ccb0b341351df79773367aa6d895b89647ceb9a75fff1c434ee480513515d112",
+    "zh:e39f56174f61556f2937fe50035703346833555cb83f2a880e3a4d832262120e",
+    "zh:f792f8b620551198807bed0752453ff0574b1b7b03ec9d9a580177b84049c700",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.0.0"
+  constraints = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "1.10.6"
+  constraints = "1.10.6"
+  hashes = [
+    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
+    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
+    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
+    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
+    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
+    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
+    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
+    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
+    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
+    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
+    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
+    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rke" {
+  version     = "1.1.6"
+  constraints = "1.1.6"
+  hashes = [
+    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
+    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
+    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
+    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
+    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
+    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
+    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+  ]
+}

--- a/do/README.md
+++ b/do/README.md
@@ -32,7 +32,7 @@ Kubernetes version to use for Rancher server RKE cluster
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.10-rancher1-2"`**
+- Default: **`"v1.18.12-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.

--- a/do/README.md
+++ b/do/README.md
@@ -44,7 +44,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.2"`**
+- Default: **`"v2.5.3"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/do/README.md
+++ b/do/README.md
@@ -26,7 +26,7 @@ Droplet size used for all droplets
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.3-rancher1-2"`**
+- Default: **`"v1.19.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -38,7 +38,7 @@ variable "rke_kubernetes_version" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.10-rancher1-2"
+  default     = "v1.18.12-rancher1-1"
 }
 
 variable "cert_manager_version" {

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -50,7 +50,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.2"
+  default     = "v2.5.3"
 }
 
 variable "rancher_server_admin_password" {

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -32,7 +32,7 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.3-rancher1-2"
+  default     = "v1.19.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {

--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -1,0 +1,126 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/banzaicloud/k8s" {
+  version     = "0.8.2"
+  constraints = "0.8.2"
+  hashes = [
+    "h1:kz2tBOpjc1nAonsB7LivtLTknStLZOu8cJO+/S6ws/4=",
+    "zh:0c35fc49c921ae981c29222a199cab012826f1ef2bbbe7c92741abad18d0f36a",
+    "zh:334e72d8b8d3d94cceb7a1ba6acbfbafde100e0714e58ebc759692e3e0a7ce19",
+    "zh:4ca36e8a85ee5bf0fe86f1f741423b164a2171fc9e53d3f913fe6b3739256ed6",
+    "zh:5b1b49dfcd560fadb392d4328fc5f66a17b6d9dd56816de4960df50cbf6b25d0",
+    "zh:95ee0507821e02f969067b835d629d2da474617177c0f8bee09c524967f19636",
+    "zh:977e10f1bc4228634d42c3d2b01c50850e411b1c7283109ff6046fcdb0a17987",
+    "zh:addccf62780281388e98acaf481ef2e296e46d3abd0130ac48876ecfef94d482",
+    "zh:bcfeae859dd9dbafabfab5fb89b13f523f82e92e3e105d01cb8566e16451d609",
+    "zh:ce796318e24c17cb6c40bd109bf15329e6e475eecc262660c1de9b5856c248ae",
+    "zh:d3ae0e6efad223f0857afca8e09ad40ac6c9e2b454b32705d4a785a3a8f5fe37",
+    "zh:e00f1c5d7c7c37d12791e7ad2ce58bbcec84f1c304aa7485be34355e7523f1db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "3.44.0"
+  constraints = "3.44.0"
+  hashes = [
+    "h1:S9INYEKYVB8r3XT/TqAVltxpdRR0VOzO7GogAvt7MdE=",
+    "zh:02e9239dde1fac770845b9890d4dbf572d8266de0f8577dcd8cf95df1b27e2c9",
+    "zh:0f5a6bd1152b19b43f01ee402d76518b89683d3634d79ddc3d78fd27910e3461",
+    "zh:1641bb4dcb9b0fd59032b22f4ace7a49b8278b8317f25b7c43c312141bad3199",
+    "zh:2a697d5aacdb832ea7aaf1f3da13800b1d9e2aa7adb58fdda8762e494bba2c36",
+    "zh:68ebf037e8bb864a7b10341b4b9a719478e7f8752150603edbc6d58ca2d4b33d",
+    "zh:719d394cf46b591f792ddec4d5effc4feaed345e047c2fa40938b464ce3e1399",
+    "zh:8c4a23b1cba0aa425172a7f8f36f2336b85e8ad1e293e6773044c0a7b99161b6",
+    "zh:ce703d87c729ad6ea50c65198d7a2fce7c11016750701b6fc108eba0c4861d7f",
+    "zh:e12e6a473a8e4738ca472febd9b8d7c1d5b88d4e0437ce0112c6bc7d7278170a",
+    "zh:ea948dff7b95930ceb336a913a97d839a0c54460efae27b07b1fd69ebe6da491",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "1.3.2"
+  constraints = "1.3.2"
+  hashes = [
+    "h1:l8zW5Bw3Q4RbNbqyS6SIGKN0KG9WKQFo9gnhxfYV2W8=",
+    "zh:0d8e1293cb99b61d3aefbab3f1c1e258e121d860312115e23b240e8acb92b855",
+    "zh:17524fac3f1eb46901a27ecef0c054c8b5390994b2f0bd48746a5eb47e42fad5",
+    "zh:74ff2d471fc934d0e65452f914248c23394937a9b4cfb560ce920d5c42568303",
+    "zh:855255f4afe7b86d88744f5615b6b6a6172fa7fc28c24d8fb5838b715e3b8a97",
+    "zh:8b3bb0f0e2e6908c3d41ee183451cb388a80cf576b0953ad3d1e06cb4de22842",
+    "zh:b46d607cedfefc94460bbff8a9d46e50f7dce364dc4050a2df81357159e07f81",
+    "zh:c9b9f3b0e6aaec7081230df257f89e00e522a3a283197126d88ae646551cde6e",
+    "zh:ccb0b341351df79773367aa6d895b89647ceb9a75fff1c434ee480513515d112",
+    "zh:e39f56174f61556f2937fe50035703346833555cb83f2a880e3a4d832262120e",
+    "zh:f792f8b620551198807bed0752453ff0574b1b7b03ec9d9a580177b84049c700",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.0.0"
+  constraints = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "1.10.6"
+  constraints = "1.10.6"
+  hashes = [
+    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
+    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
+    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
+    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
+    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
+    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
+    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
+    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
+    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
+    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
+    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
+    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rke" {
+  version     = "1.1.6"
+  constraints = "1.1.6"
+  hashes = [
+    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
+    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
+    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
+    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
+    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
+    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
+    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+  ]
+}

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -31,7 +31,7 @@ Machine type used for all compute instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.3-rancher1-2"`**
+- Default: **`"v1.19.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -37,7 +37,7 @@ Kubernetes version to use for Rancher server RKE cluster
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.10-rancher1-2"`**
+- Default: **`"v1.18.12-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -49,7 +49,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.2"`**
+- Default: **`"v2.5.3"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -43,7 +43,7 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.3-rancher1-2"
+  default     = "v1.19.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -61,7 +61,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.2"
+  default     = "v2.5.3"
 }
 
 # Required

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -49,7 +49,7 @@ variable "rke_kubernetes_version" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.10-rancher1-2"
+  default     = "v1.18.12-rancher1-1"
 }
 
 variable "cert_manager_version" {

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -26,7 +26,7 @@ Private key used for SSH access to the Rancher server cluster node
 Expected to be in PEM format.
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.3-rancher1-2"`**
+- Default: **`"v1.19.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 ###### `cert_manager_version`

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -37,7 +37,7 @@ Available versions are found in `files/cert-manager`, where a supported version
 is indicated by the presence of `crds-${var.cert_manager_version}.yaml`.
 
 ###### `rancher_version`
-- Default: **`"v2.5.2"`**
+- Default: **`"v2.5.3"`**
 Rancher server version (format `v0.0.0`)
 
 ###### `rancher_server_dns`

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -56,7 +56,7 @@ Admin password to use for Rancher server bootstrap
 Log in to the Rancher server using username `admin` and this password.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.10-rancher1-2"`**
+- Default: **`"v1.18.12-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 Defaulted to one version behind most recent minor release to allow experimenting

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -27,7 +27,7 @@ variable "ssh_private_key_pem" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.3-rancher1-2"
+  default     = "v1.19.4-rancher1-1"
 }
 
 variable "cert_manager_version" {

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -57,7 +57,7 @@ variable "admin_password" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.10-rancher1-2"
+  default     = "v1.18.12-rancher1-1"
 }
 
 # Required

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -39,7 +39,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format v0.0.0)"
-  default     = "v2.5.2"
+  default     = "v2.5.3"
 }
 
 # Required

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -18,7 +18,7 @@ terraform {
     }
     rke = {
       source  = "rancher/rke"
-      version = "1.1.5"
+      version = "1.1.6"
     }
   }
   required_version = ">= 0.13"

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,5 +1,5 @@
 admin_password: admin
-rancher_version: v2.5.2
+rancher_version: v2.5.3
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available
 k8s_version: ""


### PR DESCRIPTION
Includes the following updates:

* Rancher to 2.5.3
* terraform-provider-rke to 1.1.6
* RKE cluster version v1.19.4-rancher1-1
* Workload cluster version v1.18.12-rancher1-1

I also added the new terraform provider lock files.