### PR TITLE
Add option to spin up windows cluster

### DIFF
--- a/aws/data.tf
+++ b/aws/data.tf
@@ -18,3 +18,18 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 }
+
+data "aws_ami" "windows" {
+  most_recent = true
+  owners      = ["801119661308"] #Amazon
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2019-English-Full-ContainersLatest-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+}

--- a/aws/files/userdata_quickstart_win.template
+++ b/aws/files/userdata_quickstart_win.template
@@ -1,0 +1,17 @@
+<powershell>
+$headers = @{
+    'X-aws-ec2-metadata-token-ttl-seconds' = '21600'
+}
+$token = Invoke-RestMethod -Method 'Put' -Headers $headers -Uri http://169.254.169.254/latest/api/token
+
+$headers = @{
+    'X-aws-ec2-metadata-token' = $token
+}
+$publicIp = Invoke-RestMethod -Method 'Get' -Headers $headers -Uri http://169.254.169.254/latest/meta-data/public-ipv4
+$privateIp = Invoke-RestMethod -Method 'Get' -Headers $headers -Uri http://169.254.169.254/latest/meta-data/local-ipv4
+
+$command = '${register_command}'
+$command = $command -replace '\| iex}"','--address $publicIP --internal-address $privateIP --worker \| iex}"'
+
+$command | iex
+</powershell>

--- a/aws/infra.tf
+++ b/aws/infra.tf
@@ -109,6 +109,7 @@ module "rancher_common" {
 
   windows_prefered_cluster = var.windows_cluster
   rke_network_plugin       = var.windows_cluster ? "flannel" : "canal"
+  rke_network_options      = var.windows_cluster ? var.rancher_windows_network_options : null
 }
 
 # AWS EC2 instance for creating a single node workload cluster

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -42,3 +42,5 @@ rancher_server_admin_password = ""
 # Version of Rancher to install
 # rancher_version = ""
 
+# Whether to create a windows cluster
+# windows_cluster = false

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -32,6 +32,18 @@ variable "instance_type" {
   default     = "t3a.medium"
 }
 
+variable "instance_type_win" {
+  type        = string
+  description = "Instance type used for all Windows EC2 instances"
+  default     = "t3a.large"
+}
+
+variable "windows_cluster" {
+  type        = bool
+  description = "Whether to create a windows cluster and add windows node"
+  default     = false
+}
+
 variable "docker_version" {
   type        = string
   description = "Docker version to install on nodes"
@@ -59,7 +71,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 # Required

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -80,6 +80,15 @@ variable "rancher_server_admin_password" {
   description = "Admin password to use for Rancher server bootstrap"
 }
 
+variable "rancher_windows_network_options" {
+  description = "Network options for windows flannel"
+  default = {
+    flannel_backend_port = 4789
+    flannel_backend_type = "vxlan"
+    flannel_backend_vni  = 4096
+  }
+}
+
 
 # Local variables used to reduce repetition
 locals {


### PR DESCRIPTION
This PR bumps the version of rancher in the AWS quickstart, and also adds an option to spin up a windows cluster.