### PR TITLE
Update Rancher to 2.5.7

### DIFF
--- a/aws/.terraform.lock.hcl
+++ b/aws/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.10.6"
-  constraints = "1.10.6"
+  version     = "1.11.0"
+  constraints = "1.11.0"
   hashes = [
-    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
-    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
-    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
-    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
-    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
-    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
-    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
-    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
-    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
-    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
-    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
-    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
+    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
+    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
+    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
+    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
+    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
+    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
+    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
+    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
+    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
+    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
+    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.6"
-  constraints = "1.1.6"
+  version     = "1.1.7"
+  constraints = "1.1.7"
   hashes = [
-    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
-    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
-    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
-    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
-    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
-    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
-    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
+    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
+    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
+    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
+    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
+    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
+    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
   ]
 }

--- a/aws/.terraform.lock.hcl
+++ b/aws/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.11.0"
-  constraints = "1.11.0"
+  version     = "1.12.0"
+  constraints = "1.12.0"
   hashes = [
-    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
-    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
-    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
-    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
-    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
-    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
-    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
-    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
-    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
-    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
-    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
-    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
+    "h1:v/C9tKn1EY7mo6sMS4u0r+usMmBHBER+ugLQ+26k1xg=",
+    "zh:08375225138bc85305357e80c01fe0e3c10edf78b8623b20d4f3236753ee412d",
+    "zh:0f8d6d0ca45eddd69c548951a7705ba7df5b49ddaff836bd1e77cd37a4324f83",
+    "zh:3e22612b71e4d70fe76cd05ed0f17387abb5973a7e2dfee65b8fd7eb8104943c",
+    "zh:44dc9c2175f92b140e50fe0fef2f7789fbcf818ed3a877162aa677ac875a1cb7",
+    "zh:6c8be2e1e056a8197d3be47775b3fa4cfee28aed47db860dbcbf33c6d98cd526",
+    "zh:8691fecb23dac6a77821950d591bdadf6b4554bc7712b24513de239e0397a548",
+    "zh:a2bfd1fcf789ec0ebb0da201f0ef12bbd2974fbdeb6cefd41ca8a9f520f07f27",
+    "zh:b752e6c4a324a5328c1db1760cfb5252d4495f0af9411d71bd18cda799c11634",
+    "zh:bda644d9b7c90314316b06b5808065889c8386e4fdfad103051a5a6998f6e470",
+    "zh:c5cbdb581c02bb8c8063435549bb53c991233ad3946144858100c4c10db2259c",
+    "zh:fc2b5d58d7fe89d424193afc1f524a17f97fb306272960cf4087707e2bad1784",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.7"
-  constraints = "1.1.7"
+  version     = "1.2.1"
+  constraints = "1.2.1"
   hashes = [
-    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
-    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
-    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
-    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
-    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
-    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
-    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
+    "h1:kPe8pDvdVlW6OGKGWMtMS8ddl6zdimyFtR69r+2dUa8=",
+    "zh:49a06fdcbec632665175716defe37e7d9867e539c34cb27e0f36fc3b269f2252",
+    "zh:afb4341cf562fccee62509cf61b2eb8889c6666516d745371c1903b672c366ae",
+    "zh:c3d7e0bd1a2afb129f293ad9b78b727ff188404445c50abe734f105f2e7d62e0",
+    "zh:d9a0bd876a575c21115a58c177f601eb1cde4c11af0f9be8f7d6f024cc89bfae",
+    "zh:e1f8bd3a740322eb0e669b08543760db25d5754a703f5773ece50d533d7d57f2",
+    "zh:e5f1f4a7d33da5834024fab3c4949e7852afcb99ffa62d5702017309ca661ea7",
   ]
 }

--- a/aws/README.md
+++ b/aws/README.md
@@ -31,13 +31,13 @@ Instance type used for all EC2 instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.4-rancher1-1"`**
+- Default: **`"v1.19.6-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.12-rancher1-1"`**
+- Default: **`"v1.18.14-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -49,7 +49,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.3"`**
+- Default: **`"v2.5.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/aws/README.md
+++ b/aws/README.md
@@ -31,13 +31,13 @@ Instance type used for all EC2 instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.6-rancher1-1"`**
+- Default: **`"v1.20.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.14-rancher1-1"`**
+- Default: **`"v1.19.8-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -49,7 +49,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.5"`**
+- Default: **`"v2.5.7"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -41,13 +41,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.6-rancher1-1"
+  default     = "v1.20.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.14-rancher1-1"
+  default     = "v1.19.8-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -59,7 +59,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.5"
+  default     = "v2.5.7"
 }
 
 # Required

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -41,13 +41,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.4-rancher1-1"
+  default     = "v1.19.6-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.12-rancher1-1"
+  default     = "v1.18.14-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -59,7 +59,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 # Required

--- a/azure-windows/.terraform.lock.hcl
+++ b/azure-windows/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.10.6"
-  constraints = "1.10.6"
+  version     = "1.11.0"
+  constraints = "1.11.0"
   hashes = [
-    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
-    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
-    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
-    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
-    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
-    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
-    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
-    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
-    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
-    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
-    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
-    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
+    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
+    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
+    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
+    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
+    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
+    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
+    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
+    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
+    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
+    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
+    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.6"
-  constraints = "1.1.6"
+  version     = "1.1.7"
+  constraints = "1.1.7"
   hashes = [
-    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
-    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
-    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
-    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
-    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
-    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
-    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
+    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
+    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
+    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
+    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
+    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
+    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
   ]
 }

--- a/azure-windows/.terraform.lock.hcl
+++ b/azure-windows/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.11.0"
-  constraints = "1.11.0"
+  version     = "1.12.0"
+  constraints = "1.12.0"
   hashes = [
-    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
-    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
-    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
-    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
-    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
-    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
-    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
-    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
-    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
-    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
-    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
-    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
+    "h1:v/C9tKn1EY7mo6sMS4u0r+usMmBHBER+ugLQ+26k1xg=",
+    "zh:08375225138bc85305357e80c01fe0e3c10edf78b8623b20d4f3236753ee412d",
+    "zh:0f8d6d0ca45eddd69c548951a7705ba7df5b49ddaff836bd1e77cd37a4324f83",
+    "zh:3e22612b71e4d70fe76cd05ed0f17387abb5973a7e2dfee65b8fd7eb8104943c",
+    "zh:44dc9c2175f92b140e50fe0fef2f7789fbcf818ed3a877162aa677ac875a1cb7",
+    "zh:6c8be2e1e056a8197d3be47775b3fa4cfee28aed47db860dbcbf33c6d98cd526",
+    "zh:8691fecb23dac6a77821950d591bdadf6b4554bc7712b24513de239e0397a548",
+    "zh:a2bfd1fcf789ec0ebb0da201f0ef12bbd2974fbdeb6cefd41ca8a9f520f07f27",
+    "zh:b752e6c4a324a5328c1db1760cfb5252d4495f0af9411d71bd18cda799c11634",
+    "zh:bda644d9b7c90314316b06b5808065889c8386e4fdfad103051a5a6998f6e470",
+    "zh:c5cbdb581c02bb8c8063435549bb53c991233ad3946144858100c4c10db2259c",
+    "zh:fc2b5d58d7fe89d424193afc1f524a17f97fb306272960cf4087707e2bad1784",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.7"
-  constraints = "1.1.7"
+  version     = "1.2.1"
+  constraints = "1.2.1"
   hashes = [
-    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
-    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
-    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
-    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
-    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
-    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
-    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
+    "h1:kPe8pDvdVlW6OGKGWMtMS8ddl6zdimyFtR69r+2dUa8=",
+    "zh:49a06fdcbec632665175716defe37e7d9867e539c34cb27e0f36fc3b269f2252",
+    "zh:afb4341cf562fccee62509cf61b2eb8889c6666516d745371c1903b672c366ae",
+    "zh:c3d7e0bd1a2afb129f293ad9b78b727ff188404445c50abe734f105f2e7d62e0",
+    "zh:d9a0bd876a575c21115a58c177f601eb1cde4c11af0f9be8f7d6f024cc89bfae",
+    "zh:e1f8bd3a740322eb0e669b08543760db25d5754a703f5773ece50d533d7d57f2",
+    "zh:e5f1f4a7d33da5834024fab3c4949e7852afcb99ffa62d5702017309ca661ea7",
   ]
 }

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -40,13 +40,13 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.6-rancher1-1"`**
+- Default: **`"v1.20.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.14-rancher1-1"`**
+- Default: **`"v1.19.8-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -58,7 +58,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.5"`**
+- Default: **`"v2.5.7"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure-windows/README.md
+++ b/azure-windows/README.md
@@ -40,13 +40,13 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.4-rancher1-1"`**
+- Default: **`"v1.19.6-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.12-rancher1-1"`**
+- Default: **`"v1.18.14-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -58,7 +58,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.3"`**
+- Default: **`"v2.5.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -47,13 +47,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.4-rancher1-1"
+  default     = "v1.19.6-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.12-rancher1-1"
+  default     = "v1.18.14-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -65,7 +65,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 # Required

--- a/azure-windows/variables.tf
+++ b/azure-windows/variables.tf
@@ -47,13 +47,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.6-rancher1-1"
+  default     = "v1.20.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.14-rancher1-1"
+  default     = "v1.19.8-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -65,7 +65,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.5"
+  default     = "v2.5.7"
 }
 
 # Required

--- a/azure/.terraform.lock.hcl
+++ b/azure/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.10.6"
-  constraints = "1.10.6"
+  version     = "1.11.0"
+  constraints = "1.11.0"
   hashes = [
-    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
-    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
-    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
-    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
-    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
-    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
-    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
-    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
-    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
-    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
-    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
-    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
+    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
+    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
+    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
+    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
+    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
+    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
+    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
+    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
+    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
+    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
+    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.6"
-  constraints = "1.1.6"
+  version     = "1.1.7"
+  constraints = "1.1.7"
   hashes = [
-    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
-    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
-    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
-    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
-    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
-    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
-    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
+    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
+    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
+    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
+    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
+    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
+    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
   ]
 }

--- a/azure/.terraform.lock.hcl
+++ b/azure/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.11.0"
-  constraints = "1.11.0"
+  version     = "1.12.0"
+  constraints = "1.12.0"
   hashes = [
-    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
-    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
-    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
-    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
-    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
-    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
-    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
-    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
-    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
-    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
-    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
-    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
+    "h1:v/C9tKn1EY7mo6sMS4u0r+usMmBHBER+ugLQ+26k1xg=",
+    "zh:08375225138bc85305357e80c01fe0e3c10edf78b8623b20d4f3236753ee412d",
+    "zh:0f8d6d0ca45eddd69c548951a7705ba7df5b49ddaff836bd1e77cd37a4324f83",
+    "zh:3e22612b71e4d70fe76cd05ed0f17387abb5973a7e2dfee65b8fd7eb8104943c",
+    "zh:44dc9c2175f92b140e50fe0fef2f7789fbcf818ed3a877162aa677ac875a1cb7",
+    "zh:6c8be2e1e056a8197d3be47775b3fa4cfee28aed47db860dbcbf33c6d98cd526",
+    "zh:8691fecb23dac6a77821950d591bdadf6b4554bc7712b24513de239e0397a548",
+    "zh:a2bfd1fcf789ec0ebb0da201f0ef12bbd2974fbdeb6cefd41ca8a9f520f07f27",
+    "zh:b752e6c4a324a5328c1db1760cfb5252d4495f0af9411d71bd18cda799c11634",
+    "zh:bda644d9b7c90314316b06b5808065889c8386e4fdfad103051a5a6998f6e470",
+    "zh:c5cbdb581c02bb8c8063435549bb53c991233ad3946144858100c4c10db2259c",
+    "zh:fc2b5d58d7fe89d424193afc1f524a17f97fb306272960cf4087707e2bad1784",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.7"
-  constraints = "1.1.7"
+  version     = "1.2.1"
+  constraints = "1.2.1"
   hashes = [
-    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
-    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
-    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
-    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
-    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
-    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
-    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
+    "h1:kPe8pDvdVlW6OGKGWMtMS8ddl6zdimyFtR69r+2dUa8=",
+    "zh:49a06fdcbec632665175716defe37e7d9867e539c34cb27e0f36fc3b269f2252",
+    "zh:afb4341cf562fccee62509cf61b2eb8889c6666516d745371c1903b672c366ae",
+    "zh:c3d7e0bd1a2afb129f293ad9b78b727ff188404445c50abe734f105f2e7d62e0",
+    "zh:d9a0bd876a575c21115a58c177f601eb1cde4c11af0f9be8f7d6f024cc89bfae",
+    "zh:e1f8bd3a740322eb0e669b08543760db25d5754a703f5773ece50d533d7d57f2",
+    "zh:e5f1f4a7d33da5834024fab3c4949e7852afcb99ffa62d5702017309ca661ea7",
   ]
 }

--- a/azure/README.md
+++ b/azure/README.md
@@ -39,13 +39,13 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.4-rancher1-1"`**
+- Default: **`"v1.19.6-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.12-rancher1-1"`**
+- Default: **`"v1.18.14-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -57,7 +57,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.3"`**
+- Default: **`"v2.5.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure/README.md
+++ b/azure/README.md
@@ -39,13 +39,13 @@ Instance type used for all linux virtual instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.6-rancher1-1"`**
+- Default: **`"v1.20.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.14-rancher1-1"`**
+- Default: **`"v1.19.8-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -57,7 +57,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.5"`**
+- Default: **`"v2.5.7"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -47,13 +47,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.4-rancher1-1"
+  default     = "v1.19.6-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.12-rancher1-1"
+  default     = "v1.18.14-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -65,7 +65,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 # Required

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -47,13 +47,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.6-rancher1-1"
+  default     = "v1.20.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.14-rancher1-1"
+  default     = "v1.19.8-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -65,7 +65,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.5"
+  default     = "v2.5.7"
 }
 
 # Required

--- a/do/.terraform.lock.hcl
+++ b/do/.terraform.lock.hcl
@@ -94,34 +94,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.11.0"
-  constraints = "1.11.0"
+  version     = "1.12.0"
+  constraints = "1.12.0"
   hashes = [
-    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
-    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
-    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
-    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
-    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
-    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
-    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
-    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
-    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
-    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
-    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
-    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
+    "h1:v/C9tKn1EY7mo6sMS4u0r+usMmBHBER+ugLQ+26k1xg=",
+    "zh:08375225138bc85305357e80c01fe0e3c10edf78b8623b20d4f3236753ee412d",
+    "zh:0f8d6d0ca45eddd69c548951a7705ba7df5b49ddaff836bd1e77cd37a4324f83",
+    "zh:3e22612b71e4d70fe76cd05ed0f17387abb5973a7e2dfee65b8fd7eb8104943c",
+    "zh:44dc9c2175f92b140e50fe0fef2f7789fbcf818ed3a877162aa677ac875a1cb7",
+    "zh:6c8be2e1e056a8197d3be47775b3fa4cfee28aed47db860dbcbf33c6d98cd526",
+    "zh:8691fecb23dac6a77821950d591bdadf6b4554bc7712b24513de239e0397a548",
+    "zh:a2bfd1fcf789ec0ebb0da201f0ef12bbd2974fbdeb6cefd41ca8a9f520f07f27",
+    "zh:b752e6c4a324a5328c1db1760cfb5252d4495f0af9411d71bd18cda799c11634",
+    "zh:bda644d9b7c90314316b06b5808065889c8386e4fdfad103051a5a6998f6e470",
+    "zh:c5cbdb581c02bb8c8063435549bb53c991233ad3946144858100c4c10db2259c",
+    "zh:fc2b5d58d7fe89d424193afc1f524a17f97fb306272960cf4087707e2bad1784",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.7"
-  constraints = "1.1.7"
+  version     = "1.2.1"
+  constraints = "1.2.1"
   hashes = [
-    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
-    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
-    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
-    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
-    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
-    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
-    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
+    "h1:kPe8pDvdVlW6OGKGWMtMS8ddl6zdimyFtR69r+2dUa8=",
+    "zh:49a06fdcbec632665175716defe37e7d9867e539c34cb27e0f36fc3b269f2252",
+    "zh:afb4341cf562fccee62509cf61b2eb8889c6666516d745371c1903b672c366ae",
+    "zh:c3d7e0bd1a2afb129f293ad9b78b727ff188404445c50abe734f105f2e7d62e0",
+    "zh:d9a0bd876a575c21115a58c177f601eb1cde4c11af0f9be8f7d6f024cc89bfae",
+    "zh:e1f8bd3a740322eb0e669b08543760db25d5754a703f5773ece50d533d7d57f2",
+    "zh:e5f1f4a7d33da5834024fab3c4949e7852afcb99ffa62d5702017309ca661ea7",
   ]
 }

--- a/do/.terraform.lock.hcl
+++ b/do/.terraform.lock.hcl
@@ -94,34 +94,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.10.6"
-  constraints = "1.10.6"
+  version     = "1.11.0"
+  constraints = "1.11.0"
   hashes = [
-    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
-    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
-    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
-    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
-    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
-    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
-    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
-    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
-    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
-    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
-    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
-    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
+    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
+    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
+    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
+    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
+    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
+    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
+    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
+    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
+    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
+    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
+    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.6"
-  constraints = "1.1.6"
+  version     = "1.1.7"
+  constraints = "1.1.7"
   hashes = [
-    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
-    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
-    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
-    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
-    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
-    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
-    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
+    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
+    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
+    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
+    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
+    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
+    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
   ]
 }

--- a/do/README.md
+++ b/do/README.md
@@ -26,13 +26,13 @@ Droplet size used for all droplets
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.6-rancher1-1"`**
+- Default: **`"v1.20.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.14-rancher1-1"`**
+- Default: **`"v1.19.8-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -44,7 +44,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.5"`**
+- Default: **`"v2.5.7"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/do/README.md
+++ b/do/README.md
@@ -26,13 +26,13 @@ Droplet size used for all droplets
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.4-rancher1-1"`**
+- Default: **`"v1.19.6-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.12-rancher1-1"`**
+- Default: **`"v1.18.14-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -44,7 +44,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.3"`**
+- Default: **`"v2.5.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -32,13 +32,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.6-rancher1-1"
+  default     = "v1.20.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.14-rancher1-1"
+  default     = "v1.19.8-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -50,7 +50,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.5"
+  default     = "v2.5.7"
 }
 
 variable "rancher_server_admin_password" {

--- a/do/variables.tf
+++ b/do/variables.tf
@@ -32,13 +32,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.4-rancher1-1"
+  default     = "v1.19.6-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.12-rancher1-1"
+  default     = "v1.18.14-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -50,7 +50,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 variable "rancher_server_admin_password" {

--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.10.6"
-  constraints = "1.10.6"
+  version     = "1.11.0"
+  constraints = "1.11.0"
   hashes = [
-    "h1:WfAiAOWDgzFEl3QlX8LcLBVeF6gd2RD8cYsqhlCZHSk=",
-    "zh:048799d630b4fd6190233be28f87f9c2f7ed2d2c8daa8e3890dc5a885bc20a1d",
-    "zh:061b841c8c47e86da31f19d90155172e6258a42db0c130a9e44f430440a69b92",
-    "zh:18dc67636faf3f28d218fd3cc007338c0f2c878817d827f780832380d9b33166",
-    "zh:21a68c4ebf3bac0e9b1b4b5cccb20ac34900c4a07ce441fdac66e00e2e881283",
-    "zh:23c03d31a0bb4fafc4cffb1ba9c46e673cdefe6592de1ebcc972cbdb42137635",
-    "zh:2575aa0184b34048af7750c8a43a43860302c86e5d60fcbab7423f00ddc207b2",
-    "zh:4d55de6800dc76d47e29907b745682417255b0c24a63258a92e3c2a6287456ae",
-    "zh:9a529db6a5a23501bc2c7ff4616afe804bd588045ec7909cf45ad08a257515d5",
-    "zh:9d1662c4b090549f629473c4dd27c0b31c8d9fc3079466c0c3a47dd30d1b3aee",
-    "zh:d1c4a3a3a76151d18e2b51cba5deb68767ebe708c473f263adcbeab6450e3958",
-    "zh:f6c9402a32d062472fafd28deb47277a46d09f6821fbd3829dcdbc09a95d8a44",
+    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
+    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
+    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
+    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
+    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
+    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
+    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
+    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
+    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
+    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
+    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
+    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.6"
-  constraints = "1.1.6"
+  version     = "1.1.7"
+  constraints = "1.1.7"
   hashes = [
-    "h1:ady8JujBfH+wquQNOKPektwQ7pyiTIN+GLjM+jtplME=",
-    "zh:08683a9050422127a9ed2dfee1ac938075a5f04b9adbd70873adfc6fbd8b1597",
-    "zh:1145d4dd581c9b0dce52ec8da2ff5d56512f2d36bd53e8d19e210f67047c07c1",
-    "zh:392ea255ec6275c57dd5cfcbdd8fb9e5bc0f3f878fddf85740ce92748e1093bb",
-    "zh:4d4bdcecb39f89ba9c40dfaa692426e649b042c984a91fd15ae09e5deed4e705",
-    "zh:da4bdb562c839ffd9c55061bb6452a03ec2b0db628b43a4c47eac48407c27e61",
-    "zh:f7d39b62fd7c86e4bf6a1e6c30a72607e4877a81dfcd836db853592b356973f9",
+    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
+    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
+    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
+    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
+    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
+    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
+    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
   ]
 }

--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -93,34 +93,34 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/rancher/rancher2" {
-  version     = "1.11.0"
-  constraints = "1.11.0"
+  version     = "1.12.0"
+  constraints = "1.12.0"
   hashes = [
-    "h1:56L0xV7ugf4/7QVcznBN32Dp5b15+LmL3boNmUXE788=",
-    "zh:1c7464f4a8711a92a06e1d5deb3f3785223f924bdf645b6ebe42d4d3783d0fee",
-    "zh:716e543ae2e817bb48b80f0c10e014215b58f2521c731b5bdac0177886aa4150",
-    "zh:748512912c686d4f1c578d9db890f091953cb5818eaec91cf49df58050e7b0d9",
-    "zh:95bc35405b562ada9b33fc39ee6e1668842a59c74bce9b5912779b65c3a58936",
-    "zh:98d4f138bfffdd0f73233250b22aefd7255bfac973d7bbd7677ee4decbe55ce2",
-    "zh:9d2e543000268efcabec16d11cbe3a6e605d9d2587588aa630ec81133f5d460a",
-    "zh:afa56b1e34cbfd9eb26e6ef8bda27a875974da7524c7ca2bb5522c0d397b4a23",
-    "zh:b296cd8bfeabc53d42328b3b621406349dde765f7d64157cb6df64507b29c931",
-    "zh:b40e9b1ccf2f2b00295565453761b1baa489a9a9bf362932aa16c9d5ec4e94a9",
-    "zh:d4124ce4fea3537f6401441d2b2f49c1d59c1efad06654f7b68691831924ecf6",
-    "zh:db56682e90228868e3ceba1f394ccf9e2b5fc5ae57b73ba953b37b2bb9adc258",
+    "h1:v/C9tKn1EY7mo6sMS4u0r+usMmBHBER+ugLQ+26k1xg=",
+    "zh:08375225138bc85305357e80c01fe0e3c10edf78b8623b20d4f3236753ee412d",
+    "zh:0f8d6d0ca45eddd69c548951a7705ba7df5b49ddaff836bd1e77cd37a4324f83",
+    "zh:3e22612b71e4d70fe76cd05ed0f17387abb5973a7e2dfee65b8fd7eb8104943c",
+    "zh:44dc9c2175f92b140e50fe0fef2f7789fbcf818ed3a877162aa677ac875a1cb7",
+    "zh:6c8be2e1e056a8197d3be47775b3fa4cfee28aed47db860dbcbf33c6d98cd526",
+    "zh:8691fecb23dac6a77821950d591bdadf6b4554bc7712b24513de239e0397a548",
+    "zh:a2bfd1fcf789ec0ebb0da201f0ef12bbd2974fbdeb6cefd41ca8a9f520f07f27",
+    "zh:b752e6c4a324a5328c1db1760cfb5252d4495f0af9411d71bd18cda799c11634",
+    "zh:bda644d9b7c90314316b06b5808065889c8386e4fdfad103051a5a6998f6e470",
+    "zh:c5cbdb581c02bb8c8063435549bb53c991233ad3946144858100c4c10db2259c",
+    "zh:fc2b5d58d7fe89d424193afc1f524a17f97fb306272960cf4087707e2bad1784",
   ]
 }
 
 provider "registry.terraform.io/rancher/rke" {
-  version     = "1.1.7"
-  constraints = "1.1.7"
+  version     = "1.2.1"
+  constraints = "1.2.1"
   hashes = [
-    "h1:Ru4phRr/LsKyZiClZp0T4+crvwQc6cS9YcBxZMQ/mmU=",
-    "zh:1163acbe12001291e60e0ccff5d40524ed2aa4df8c626348e74bec63f8a37aff",
-    "zh:3aad664328330bda53e9b5788f3f8fb75ebf2fb818320c872ba9b65fca1497e5",
-    "zh:3aed499c342213064525dc427e4b25dc1d892d5229252d8b0217262184aba8e1",
-    "zh:4cf3f496323122427e1da7e8bc7d02f9f5c68660f7e8310180555d7a89d2c2f0",
-    "zh:812cf750b1ad8c254b85069b644f2ab1859e53485a3c26160d0cac29091ca828",
-    "zh:8c44a87540d9acd5078584e99aa8bd8088a8f1b55096f9ab4bf54c7c1949c6ce",
+    "h1:kPe8pDvdVlW6OGKGWMtMS8ddl6zdimyFtR69r+2dUa8=",
+    "zh:49a06fdcbec632665175716defe37e7d9867e539c34cb27e0f36fc3b269f2252",
+    "zh:afb4341cf562fccee62509cf61b2eb8889c6666516d745371c1903b672c366ae",
+    "zh:c3d7e0bd1a2afb129f293ad9b78b727ff188404445c50abe734f105f2e7d62e0",
+    "zh:d9a0bd876a575c21115a58c177f601eb1cde4c11af0f9be8f7d6f024cc89bfae",
+    "zh:e1f8bd3a740322eb0e669b08543760db25d5754a703f5773ece50d533d7d57f2",
+    "zh:e5f1f4a7d33da5834024fab3c4949e7852afcb99ffa62d5702017309ca661ea7",
   ]
 }

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -31,13 +31,13 @@ Machine type used for all compute instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.4-rancher1-1"`**
+- Default: **`"v1.19.6-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.12-rancher1-1"`**
+- Default: **`"v1.18.14-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -49,7 +49,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.3"`**
+- Default: **`"v2.5.5"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -31,13 +31,13 @@ Machine type used for all compute instances
 Docker version to install on nodes
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.6-rancher1-1"`**
+- Default: **`"v1.20.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 See `rancher-common` module variable `rke_kubernetes_version` for more details.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.14-rancher1-1"`**
+- Default: **`"v1.19.8-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 See `rancher-common` module variable `workload_kubernetes_version` for more details.
@@ -49,7 +49,7 @@ Version of cert-manager to install alongside Rancher (format: 0.0.0)
 See `rancher-common` module variable `cert_manager_version` for more details.
 
 ###### `rancher_version`
-- Default: **`"v2.5.5"`**
+- Default: **`"v2.5.7"`**
 Rancher server version (format v0.0.0)
 
 See `rancher-common` module variable `rancher_version` for more details.

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -43,13 +43,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.6-rancher1-1"
+  default     = "v1.20.4-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.14-rancher1-1"
+  default     = "v1.19.8-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -61,7 +61,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.5"
+  default     = "v2.5.7"
 }
 
 # Required

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -43,13 +43,13 @@ variable "docker_version" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.4-rancher1-1"
+  default     = "v1.19.6-rancher1-1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.12-rancher1-1"
+  default     = "v1.18.14-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -61,7 +61,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 # Required

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -26,7 +26,7 @@ Private key used for SSH access to the Rancher server cluster node
 Expected to be in PEM format.
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.4-rancher1-1"`**
+- Default: **`"v1.19.6-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 ###### `cert_manager_version`
@@ -37,7 +37,7 @@ Available versions are found in `files/cert-manager`, where a supported version
 is indicated by the presence of `crds-${var.cert_manager_version}.yaml`.
 
 ###### `rancher_version`
-- Default: **`"v2.5.3"`**
+- Default: **`"v2.5.5"`**
 Rancher server version (format `v0.0.0`)
 
 ###### `rancher_server_dns`
@@ -56,7 +56,7 @@ Admin password to use for Rancher server bootstrap
 Log in to the Rancher server using username `admin` and this password.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.12-rancher1-1"`**
+- Default: **`"v1.18.14-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 Defaulted to one version behind most recent minor release to allow experimenting

--- a/rancher-common/README.md
+++ b/rancher-common/README.md
@@ -26,7 +26,7 @@ Private key used for SSH access to the Rancher server cluster node
 Expected to be in PEM format.
 
 ###### `rke_kubernetes_version`
-- Default: **`"v1.19.6-rancher1-1"`**
+- Default: **`"v1.20.4-rancher1-1"`**
 Kubernetes version to use for Rancher server RKE cluster
 
 ###### `cert_manager_version`
@@ -37,7 +37,7 @@ Available versions are found in `files/cert-manager`, where a supported version
 is indicated by the presence of `crds-${var.cert_manager_version}.yaml`.
 
 ###### `rancher_version`
-- Default: **`"v2.5.5"`**
+- Default: **`"v2.5.7"`**
 Rancher server version (format `v0.0.0`)
 
 ###### `rancher_server_dns`
@@ -56,7 +56,7 @@ Admin password to use for Rancher server bootstrap
 Log in to the Rancher server using username `admin` and this password.
 
 ###### `workload_kubernetes_version`
-- Default: **`"v1.18.14-rancher1-1"`**
+- Default: **`"v1.19.8-rancher1-1"`**
 Kubernetes version to use for managed workload cluster
 
 Defaulted to one version behind most recent minor release to allow experimenting

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -27,7 +27,7 @@ variable "ssh_private_key_pem" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.6-rancher1-1"
+  default     = "v1.20.4-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -39,7 +39,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format v0.0.0)"
-  default     = "v2.5.5"
+  default     = "v2.5.7"
 }
 
 # Required
@@ -57,7 +57,7 @@ variable "admin_password" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.14-rancher1-1"
+  default     = "v1.19.8-rancher1-1"
 }
 
 # Required

--- a/rancher-common/variables.tf
+++ b/rancher-common/variables.tf
@@ -27,7 +27,7 @@ variable "ssh_private_key_pem" {
 variable "rke_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server RKE cluster"
-  default     = "v1.19.4-rancher1-1"
+  default     = "v1.19.6-rancher1-1"
 }
 
 variable "cert_manager_version" {
@@ -39,7 +39,7 @@ variable "cert_manager_version" {
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format v0.0.0)"
-  default     = "v2.5.3"
+  default     = "v2.5.5"
 }
 
 # Required
@@ -57,7 +57,7 @@ variable "admin_password" {
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.18.12-rancher1-1"
+  default     = "v1.18.14-rancher1-1"
 }
 
 # Required

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -14,11 +14,11 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = "1.11.0"
+      version = "1.12.0"
     }
     rke = {
       source  = "rancher/rke"
-      version = "1.1.7"
+      version = "1.2.1"
     }
   }
   required_version = ">= 0.13"

--- a/rancher-common/versions.tf
+++ b/rancher-common/versions.tf
@@ -14,11 +14,11 @@ terraform {
     }
     rancher2 = {
       source  = "rancher/rancher2"
-      version = "1.10.6"
+      version = "1.11.0"
     }
     rke = {
       source  = "rancher/rke"
-      version = "1.1.6"
+      version = "1.1.7"
     }
   }
   required_version = ">= 0.13"

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,5 +1,5 @@
 admin_password: admin
-rancher_version: v2.5.5
+rancher_version: v2.5.7
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available
 k8s_version: ""

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,5 +1,5 @@
 admin_password: admin
-rancher_version: v2.5.3
+rancher_version: v2.5.5
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available
 k8s_version: ""


### PR DESCRIPTION
Update Rancher to 2.5.5

This also updates

* terraform-provider-rke to 1.1.7
* terraform-provider-rancher2 to 1.11.0
* RKE Kubernetes version to v1.19.6-rancher1-1
* Workload cluster Kubernetes version to v1.18.12-rancher1-1
