### PR TITLE
added possibility to have a local configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ kube_config*
 
 # vagrant files
 .vagrant/
+vagrant/local_config.yaml
 
 # MacOS junk
 .DS_Store

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -16,6 +16,8 @@ This folder contains Vagrant code to stand up a single Rancher server instance w
 When provisioning is finished the Rancher UI will become accessible on [172.22.101.101](http://172.22.101.101).
 The default password is `admin`, but this can be updated in the config.yaml file.
 
+If you want to keep the configuration changes outside the git repository you can copy the config.yaml file to local_config.yaml and make changes there.
+
 ## Remove
 
 To remove the VMs that have been deployed run `vagrant destroy -f`

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,7 +4,12 @@ require_relative 'vagrant_rancheros_guest_plugin.rb'
 require 'ipaddr'
 require 'yaml'
 
-x = YAML.load_file(File.join(File.dirname(__FILE__), 'config.yaml'))
+if File.exists?(File.join(File.dirname(__FILE__), "local_config.yaml")) then
+    puts "Using local configuration file"
+    x = YAML.load_file(File.join(File.dirname(__FILE__), "local_config.yaml"))
+else
+    x = YAML.load_file(File.join(File.dirname(__FILE__), 'config.yaml'))
+end
 puts "Config: #{x.inspect}\n\n"
 
 $private_nic_type = x.fetch('net').fetch('private_nic_type')


### PR DESCRIPTION
This PR adds the possibility to have a local configuration file for vagrant that is not tracked by git.

`vagrant up` will use `local_config.yaml` if it exists, if not it falls back in `config.yaml`