### PR TITLE
Migrate to nip.io

### DIFF
--- a/aws/infra.tf
+++ b/aws/infra.tf
@@ -100,7 +100,7 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = join(".", ["rancher", aws_instance.rancher_server.public_ip, "xip.io"])
+  rancher_server_dns = join(".", ["rancher", aws_instance.rancher_server.public_ip, "nip.io"])
 
   admin_password = var.rancher_server_admin_password
 

--- a/azure-windows/infra.tf
+++ b/azure-windows/infra.tf
@@ -152,7 +152,7 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = join(".", ["rancher", azurerm_linux_virtual_machine.rancher_server.public_ip_address, "xip.io"])
+  rancher_server_dns = join(".", ["rancher", azurerm_linux_virtual_machine.rancher_server.public_ip_address, "nip.io"])
 
   admin_password = var.rancher_server_admin_password
 

--- a/azure/infra.tf
+++ b/azure/infra.tf
@@ -152,7 +152,7 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = join(".", ["rancher", azurerm_linux_virtual_machine.rancher_server.public_ip_address, "xip.io"])
+  rancher_server_dns = join(".", ["rancher", azurerm_linux_virtual_machine.rancher_server.public_ip_address, "nip.io"])
 
   admin_password = var.rancher_server_admin_password
 

--- a/do/infra.tf
+++ b/do/infra.tf
@@ -68,7 +68,7 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = join(".", ["rancher", digitalocean_droplet.rancher_server.ipv4_address, "xip.io"])
+  rancher_server_dns = join(".", ["rancher", digitalocean_droplet.rancher_server.ipv4_address, "nip.io"])
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version

--- a/gcp/infra.tf
+++ b/gcp/infra.tf
@@ -101,7 +101,7 @@ module "rancher_common" {
   cert_manager_version = var.cert_manager_version
   rancher_version      = var.rancher_version
 
-  rancher_server_dns = join(".", ["rancher", google_compute_instance.rancher_server.network_interface.0.access_config.0.nat_ip, "xip.io"])
+  rancher_server_dns = join(".", ["rancher", google_compute_instance.rancher_server.network_interface.0.access_config.0.nat_ip, "nip.io"])
   admin_password     = var.rancher_server_admin_password
 
   workload_kubernetes_version = var.workload_kubernetes_version


### PR DESCRIPTION
Raising this for consideration to migrate to nip.io as the default dynamic DNS provider.

Updated references of xip.io to nip.io to resolve DNS issues during provisioning.

Tests:
- [x] A new AWS quickstart launch
- [ ] `terraform apply` on an existing quickstart launch (with xip.io)
 
Potentially related: https://github.com/rancher/quickstart/issues/165