### PR TITLE
Remove unnecessary empty provider blocks

### DIFF
--- a/rancher-common/provider.tf
+++ b/rancher-common/provider.tf
@@ -1,11 +1,3 @@
-# Local provider
-provider "local" {
-}
-
-# RKE provider
-provider "rke" {
-}
-
 # Kubernetes provider
 provider "k8s" {
   host = rke_cluster.rancher_cluster.api_server_url


### PR DESCRIPTION
Remove unnecessary empty provider blocks

These blocks are not needed and terraform prints a warning now:

```
│ Warning: Empty provider configuration blocks are not required
│
│   on ../rancher-common/provider.tf line 2:
│    2: provider "local" {
│
│ Remove the local provider block from module.rancher_common.
│
│ (and one more similar warning elsewhere)
```