### PR TITLE
Restricted AWS rancher_sg_allowall to creators IP.

### DIFF
--- a/aws/whatsmyip.sh
+++ b/aws/whatsmyip.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+INTERNETIP="$(dig +short myip.opendns.com @resolver1.opendns.com -4)"
+echo $(jq -n --arg internetip "$INTERNETIP" '{"internet_ip":$internetip}')


### PR DESCRIPTION
Limits access to the instance to reduce attack surface area.
Adds result of whatsismyip.sh to the TF.  Requires jq to be installed. 

Increased instance storage size.
