### PR TITLE
Add scaleway provider to the examples

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        provider: ['aws', 'azure', 'azure-windows', 'do', 'gcp']
+        provider: ['aws', 'azure', 'azure-windows', 'do', 'gcp', 'scw']
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [/vagrant](./vagrant) for details on usage and settings.
 
 ## Cloud quickstart
 
-Quickstarts are provided for [**Amazon Web Services** (`aws`)](./aws), [**Microsoft Azure Cloud** (`azure`)](./azure), [**Microsoft Azure Cloud with Windows nodes** (`azure-windows`)](./azure-windows), [**DigitalOcean** (`do`)](./do), and [**Google Cloud Platform** (`gcp`)](./gcp).
+Quickstarts are provided for [**Amazon Web Services** (`aws`)](./aws), [**Microsoft Azure Cloud** (`azure`)](./azure), [**Microsoft Azure Cloud with Windows nodes** (`azure-windows`)](./azure-windows), [**DigitalOcean** (`do`)](./do), [**Google Cloud Platform** (`gcp`)](./gcp), and [**Scaleway** (`scw`)](./do).
 
 **You will be responsible for any and all infrastructure costs incurred by these resources.**
 

--- a/scw/README.md
+++ b/scw/README.md
@@ -1,0 +1,81 @@
+# Scaleway Rancher Quickstart
+
+Two single-node RKE Kubernetes clusters will be created from two instances running Ubuntu 20.04 (Focal Fossa) and Docker.
+Both instances will be accessible over SSH using the SSH keys `id_rsa` and `id_rsa.pub`.
+
+## Variables
+
+###### `scw_project_id`
+
+- **Required**
+Scaleway project id used to create infrastructure
+
+###### `scw_access_key`
+
+- **Required**
+Scaleway access key used to create infrastructure
+
+###### `scw_secret_key`
+
+- **Required**
+Scaleway secret key used to create infrastructure
+
+###### `scw_zone`
+
+- Default: **`"fr-par-1"`**
+Scaleway zone used for all resources
+
+###### `scw_region`
+
+- Default: **`"fr-par"`**
+Scaleway region used for all resources
+
+###### `prefix`
+
+- Default: **`"quickstart"`**
+Prefix added to names of all resources
+
+###### `instance_type`
+
+- Default: **`"DEV1-M"`**
+Droplet size used for all droplets
+
+###### `docker_version`
+
+- Default: **`"19.03"`**
+Docker version to install on nodes
+
+###### `rke_kubernetes_version`
+
+- Default: **`"v1.20.4-rancher1-1"`**
+Kubernetes version to use for Rancher server RKE cluster
+
+See `rancher-common` module variable `rke_kubernetes_version` for more details.
+
+###### `workload_kubernetes_version`
+
+- Default: **`"v1.19.8-rancher1-1"`**
+Kubernetes version to use for managed workload cluster
+
+See `rancher-common` module variable `workload_kubernetes_version` for more details.
+
+###### `cert_manager_version`
+
+- Default: **`"1.0.4"`**
+Version of cert-manager to install alongside Rancher (format: 0.0.0)
+
+See `rancher-common` module variable `cert_manager_version` for more details.
+
+###### `rancher_version`
+
+- Default: **`"v2.5.7"`**
+Rancher server version (format v0.0.0)
+
+See `rancher-common` module variable `rancher_version` for more details.
+
+###### `rancher_server_admin_password`
+
+- **Required**
+Admin password to use for Rancher server bootstrap
+
+See `rancher-common` module variable `admin_password` for more details.

--- a/scw/infra.tf
+++ b/scw/infra.tf
@@ -1,0 +1,110 @@
+# Scaleway infrastructure resources
+
+resource "tls_private_key" "global_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "local_file" "ssh_private_key_pem" {
+  filename          = "${path.module}/id_rsa"
+  sensitive_content = tls_private_key.global_key.private_key_pem
+  file_permission   = "0600"
+}
+
+resource "local_file" "ssh_public_key_openssh" {
+  filename = "${path.module}/id_rsa.pub"
+  content  = tls_private_key.global_key.public_key_openssh
+}
+
+# Temporary key pair used for SSH accesss
+resource "scaleway_account_ssh_key" "quickstart_ssh_key" {
+  name       = "${var.prefix}-instance-ssh-key"
+  public_key = tls_private_key.global_key.public_key_openssh
+}
+
+# Scaleway instance for creating a single node RKE cluster and installing the Rancher server
+resource "scaleway_instance_server" "rancher_server" {
+  name               = "${var.prefix}-rancher-server"
+  image              = "ubuntu_focal"
+  type               = var.instance_type
+  enable_dynamic_ip  = true
+
+  user_data = {
+    cloud-init = templatefile(
+      join("/", [path.module, "../cloud-common/files/userdata_rancher_server.template"]),
+      {
+        docker_version = var.docker_version
+        username       = local.node_username
+      }
+    )
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.public_ip
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+}
+
+# Rancher resources
+module "rancher_common" {
+  source = "../rancher-common"
+
+  node_public_ip         = scaleway_instance_server.rancher_server.public_ip
+  node_internal_ip       = scaleway_instance_server.rancher_server.private_ip
+  node_username          = local.node_username
+  ssh_private_key_pem    = tls_private_key.global_key.private_key_pem
+  rke_kubernetes_version = var.rke_kubernetes_version
+
+  cert_manager_version = var.cert_manager_version
+  rancher_version      = var.rancher_version
+
+  rancher_server_dns = join(".", ["rancher", scaleway_instance_server.rancher_server.public_ip, "nip.io"])
+  admin_password     = var.rancher_server_admin_password
+
+  workload_kubernetes_version = var.workload_kubernetes_version
+  workload_cluster_name       = "quickstart-scw-custom"
+}
+
+# Scaleway instance for creating a single node workload cluster
+resource "scaleway_instance_server" "quickstart_node" {
+  name               = "${var.prefix}-quickstart-node"
+  image              = "ubuntu_focal"
+  type               = var.instance_type
+  enable_dynamic_ip  = true
+
+  user_data = {
+    cloud-init = templatefile(
+      join("/", [path.module, "../cloud-common/files/userdata_quickstart_node.template"]),
+      {
+        docker_version   = var.docker_version
+        username         = local.node_username
+        register_command = module.rancher_common.custom_cluster_command
+      }
+    )
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.public_ip
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+}

--- a/scw/output.tf
+++ b/scw/output.tf
@@ -1,0 +1,12 @@
+
+output "rancher_server_url" {
+  value = module.rancher_common.rancher_url
+}
+
+output "rancher_node_ip" {
+  value = scaleway_instance_server.rancher_server.public_ip
+}
+
+output "workload_node_ip" {
+  value = scaleway_instance_server.quickstart_node.public_ip
+}

--- a/scw/provider.tf
+++ b/scw/provider.tf
@@ -1,0 +1,10 @@
+provider "scaleway" {
+  project_id = var.scw_project_id
+  access_key = var.scw_access_key
+  secret_key = var.scw_secret_key
+  zone       = var.scw_zone
+  region     = var.scw_region
+}
+
+provider "tls" {
+}

--- a/scw/terraform.tfvars.example
+++ b/scw/terraform.tfvars.example
@@ -1,0 +1,50 @@
+# Required variables
+# - Fill in before beginning quickstart
+# ==========================================================
+
+# Scaleway project id
+scw_project_id = ""
+
+# Scaleway access key
+scw_access_key = ""
+
+# Scaleway secret key
+scw_secret_key = ""
+
+# Password used to log in to the `admin` account on the new Rancher server
+rancher_server_admin_password = ""
+
+
+# Optional variables
+# - Uncomment variables to customize quickstart
+# ----------------------------------------------------------
+
+# Scaleway zone for all resources
+# scw_zone = ""
+
+# Scaleway region for all resources
+# scw_region = ""
+
+# Prefix for all resources created by quickstart
+# prefix = ""
+
+# Type of all created instances
+# instance_type = ""
+
+# Docker version installed on target hosts
+# - Must be a version supported by the Rancher install scripts
+# docker_version = ""
+
+# Kubernetes version used for creating management server cluster
+# - Must be supported by RKE terraform provider 1.0.1
+# rke_kubernetes_version = ""
+
+# Kubernetes version used for creating workload cluster
+# - Must be supported by RKE terraform provider 1.0.1
+# workload_kubernetes_version = ""
+
+# Version of cert-manager to install, used in case of older Rancher versions
+# cert_manager_version = ""
+
+# Version of Rancher to install
+# rancher_version = ""

--- a/scw/variables.tf
+++ b/scw/variables.tf
@@ -1,0 +1,80 @@
+# Variables for Scaleway infrastructure module
+
+variable "scw_project_id" {
+  type        = string
+  description = "Scaleway project id used to create infrastructure"
+}
+
+variable "scw_access_key" {
+  type        = string
+  description = "Scaleway access key used to create infrastructure"
+}
+
+variable "scw_secret_key" {
+  type        = string
+  description = "Scaleway secret key used to create infrastructure"
+}
+
+variable "scw_zone" {
+  type        = string
+  description = "Scaleway zone used for all resources"
+  default     = "fr-par-1"
+}
+
+variable "scw_region" {
+  type        = string
+  description = "Scaleway region used for all resources"
+  default     = "fr-par"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Prefix added to names of all resources"
+  default     = "quickstart"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Instance type used for all instances"
+  default     = "DEV1-M"
+}
+
+variable "docker_version" {
+  type        = string
+  description = "Docker version to install on nodes"
+  default     = "19.03"
+}
+
+variable "rke_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for Rancher server RKE cluster"
+  default     = "v1.20.4-rancher1-1"
+}
+
+variable "workload_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for managed workload cluster"
+  default     = "v1.19.8-rancher1-1"
+}
+
+variable "cert_manager_version" {
+  type        = string
+  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
+  default     = "1.0.4"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Rancher server version (format: v0.0.0)"
+  default     = "v2.5.7"
+}
+
+variable "rancher_server_admin_password" {
+  type        = string
+  description = "Admin password to use for Rancher server bootstrap"
+}
+
+# Local variables used to reduce repetition
+locals {
+  node_username = "root"
+}

--- a/scw/versions.tf
+++ b/scw/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "2.1.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.0.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.0.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
# Why
I wanted to try this quickstart at Scaleway and it was not one of the
examples. There is one PR (https://github.com/rancher/quickstart/pull/123) open for this but it was WIP and using an
outdated version of scaleway/scaleway terraform provider.

# What changed (to help with review)
I based it in the DigitalOcean example because they clouds and terraform
providers are very similar.

Changes:

- region/zone by provider instead of per resource/instance
- `public_ip` attributes instead of `ipv4`
- ssh key/credentials are added to project instead of each instance
- image names and instance size/type

Also changed the README and the `terraform.yml` github workflow.

# Tests
Tested it and the rancher server and a RKE example workload cluster
started properly and everything seems to be working as expected.

## Screenshots
![Scaleway instances](https://user-images.githubusercontent.com/5817039/128186713-28863c45-b635-48e4-b019-76150ad15037.png)
![Rancher clusters global view](https://user-images.githubusercontent.com/5817039/128186742-9764c5fd-6f12-4116-bb40-4eb0e839e75b.png)