### PR TITLE
Bootstrap password check

### DIFF
--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,8 +1,8 @@
 admin_password: admin
-rancher_version: v2.5.7
+rancher_version: v2.6.0
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available
-k8s_version: "v1.18.15-rancher1-1"
+k8s_version: "v1.20.10-rancher1-1"
 server:
   cpus: 1
   memory: 1500

--- a/vagrant/scripts/configure_rancher_server.sh
+++ b/vagrant/scripts/configure_rancher_server.sh
@@ -59,7 +59,10 @@ APITOKEN=`echo $APIRESPONSE | docker run --rm -i $jqimage -r .token`
 RANCHER_SERVER="https://${rancher_ip}"
 docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/settings/server-url' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" -X PUT --data-binary '{"name":"server-url","value":"'$RANCHER_SERVER'"}' --insecure
 
-sleep 120
+while true; do
+  docker run --rm --net=host $curlimage -sLk https://127.0.0.1/ping && break
+  sleep 5
+done
 
 # Create cluster
 CLUSTERRESPONSE=$(docker run --rm --net=host $curlimage -s 'https://127.0.0.1/v3/cluster' -H 'content-type: application/json' -H "Authorization: Bearer $APITOKEN" --data-binary '{"dockerRootDir":"/var/lib/docker","enableNetworkPolicy":false,"type":"cluster","rancherKubernetesEngineConfig":{"kubernetesVersion":"'$k8s_version'","addonJobTimeout":30,"ignoreDockerVersion":true,"sshAgentAuth":false,"type":"rancherKubernetesEngineConfig","authentication":{"type":"authnConfig","strategy":"x509"},"network":{"options":{"flannelBackendType":"vxlan"},"plugin":"canal","canalNetworkProvider":{"iface":"eth1"}},"ingress":{"type":"ingressConfig","provider":"nginx"},"monitoring":{"type":"monitoringConfig","provider":"metrics-server"},"services":{"type":"rkeConfigServices","kubeApi":{"podSecurityPolicy":false,"type":"kubeAPIService"},"etcd":{"creation":"12h","extraArgs":{"heartbeat-interval":500,"election-timeout":5000},"retention":"72h","snapshot":false,"type":"etcdService","backupConfig":{"enabled":true,"intervalHours":12,"retention":6,"type":"backupConfig"}}}},"localClusterAuthEndpoint":{"enabled":true,"type":"localClusterAuthEndpoint"},"name":"quickstart"}' --insecure)


### PR DESCRIPTION
This pull requests adds a check to see if the docker logs contains a bootstrap password and uses that to change password specified in the config.yaml
This makes it possible to use vagrant quickstart for rancher v2.6.0

I've tested this with v2.5.7 (that doesn't use bootstrap password) and v2.6.0 of rancher