### PR TITLE
Add HCloud Provider

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        provider: ['aws', 'azure', 'do', 'gcp']
+        provider: ['aws', 'azure', 'do', 'gcp', 'hcloud']
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vagrant/local_config.yaml
 
 # MacOS junk
 .DS_Store
+
+# Terraform plan files
+*.tfplan

--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ See [/vagrant](./vagrant) for details on usage and settings.
 
 ## Cloud quickstart
 
-Quickstarts are provided for [**Amazon Web Services** (`aws`)](./aws), [**Microsoft Azure Cloud** (`azure`)](./azure), [**Microsoft Azure Cloud with Windows nodes** (`azure-windows`)](./azure-windows), [**DigitalOcean** (`do`)](./do), and [**Google Cloud Platform** (`gcp`)](./gcp).
+Quickstarts are provided for:
+
+- [**Amazon Web Services** (`aws`)](./aws)
+- [**Microsoft Azure Cloud** (`azure`)](./azure)
+- [**Microsoft Azure Cloud with Windows nodes** (`azure-windows`)](./azure-windows)
+- [**DigitalOcean** (`do`)](./do)
+- [**Google Cloud Platform** (`gcp`)](./gcp)
+- [**Hetzner Cloud** (`hcloud`)](./hcloud)
 
 **You will be responsible for any and all infrastructure costs incurred by these resources.**
 

--- a/hcloud/.terraform.lock.hcl
+++ b/hcloud/.terraform.lock.hcl
@@ -1,0 +1,120 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.3.0"
+  constraints = "2.3.0"
+  hashes = [
+    "h1:qo08yDJAnkE8H2CNuI2fVP2W+J3bOCrXWRvAerQpgc8=",
+    "zh:0c63c0aa9f13ec057971c9ddd0965e062b064c0b2ce9a3d13df41239b8f5af89",
+    "zh:14b4146e56b1c1e5492ce597d03fb993a71039dd701e3886667f7ad3d60afd34",
+    "zh:3882a3a091aeac1d42a01c7654c727a46870185d363454579e707c672a42f430",
+    "zh:3ccb84b23348e2b64ffe273170f686e6927e974060e37b52459ab2395bd59523",
+    "zh:4fb709aeb63dd6dee1e851459ac87c399ddb831ebfe9e28e4c9827c65bb55b67",
+    "zh:6739a4da9510f552b93fa77859f04c20af3a7a40a7f0b0073eb723af36b8156b",
+    "zh:7432b070124a161fe6a32dc6b76fd45100d079fdee917318460a82b80cda5518",
+    "zh:9aa51dc2a649fcaac133dad5c1e148c2e0f675fdf18b1d3b1da53549d8fa3b36",
+    "zh:a9a2abf1fbec56019473c8696d285703218ea0e8f2dc01879e7a391ea8785d57",
+    "zh:b3c25b085b7a7fbc05000303d82c54531987525575ff337e4be6fc152f4200d4",
+    "zh:fa8cb34df7786bbeffcee664eab72aeb15c4f8fba2d9c0b05faca6b3e819cf33",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.1.0"
+  constraints = "2.1.0"
+  hashes = [
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.1.0"
+  constraints = "3.1.0"
+  hashes = [
+    "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
+    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
+    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
+    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
+    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
+    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
+    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
+    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
+    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
+    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
+    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
+    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+  ]
+}
+
+provider "registry.terraform.io/hetznercloud/hcloud" {
+  version     = "1.32.1"
+  constraints = ">= 1.27.0"
+  hashes = [
+    "h1:RfLu8m+y3fKf5FrDJarSp06KS4R75yZxPy9n+Df5PjM=",
+    "zh:043e941caf46b3a37cae5f2f9c1b7ce2b30f0b492bada6f3d8d6a7384f5cb7b2",
+    "zh:055835d483dd172e7b0e500f9dd789353e32c9328d51793b8d88451df4e92067",
+    "zh:3dd5a0006ab7f464a2bca8c5a46e583c6f09ba66aeff1ca847397b61fc823597",
+    "zh:3f0444956fdcb059ee9ea54f51af016d86f297477335f519256ca158a75c5e59",
+    "zh:569a80f0c9e2f5fb121d9050bc10d6e6ba30507e2e985b809a2613dcb5bdc095",
+    "zh:5e7e8499e62408d784d4c886827d421962134a3efda5f5f4f8794f9b1c17190c",
+    "zh:67b48380e144ba4c31fff41442cbf53463eba285321d4283430b605285048923",
+    "zh:7ddc434dbefecc6b1934f683f54ad5552c9e466b5e256b9cfe67f7b28ffecc7d",
+    "zh:87c0b5f4f6b3121cc81935ccb8598a58bda20c7f96f8a4270ecb0b6b2096ba40",
+    "zh:891d2234146c3fbc2fe6d2a0c176cefd01d16d2d1d25eebe6e15909aac4a1ddf",
+    "zh:a90ced7f84d8bdd64afd00c69ea9e2b1ed43314da020860c31ff266b3716d1f0",
+    "zh:b8c86266d9f4ae4d2cca8f3f7d58a48d0c000f16aa21a733bb81c760efa690f7",
+    "zh:bf8fdd6eb8619dc20d85d418ed910a79af0b28bf79ac3a4029f0d0ae032c9c7d",
+    "zh:d6d87b405c0fd5e576a7e0a8976689d555299806484fdacca205537367d92f37",
+  ]
+}
+
+provider "registry.terraform.io/invidian/sshcommand" {
+  version     = "0.2.2"
+  constraints = "0.2.2"
+  hashes = [
+    "h1:hCfqgTFwuiXLT422LvDC3E4S9bylhQpM4nnxiBQZ+60=",
+    "zh:365c8f46d4a895088b0d157487cd606d5274a25575f411eebeb0aa9dc3fc5471",
+    "zh:48bd318ea25248cb01adc83a1f75c485addad5fcbc63344f2568604b5b0d5484",
+    "zh:4b67ecd0e34f7d6a9a21bb384d57a4f7fbdba0a393d45ba3de5bc74bdf0d0d70",
+    "zh:5f509301447a9ce55716f7d327883d7ce6d0533fd1eb10e8a4863b596155d1d8",
+    "zh:6a3275345a995448b90baa5c582e26e23ab88804c3b738798cbae908048a3701",
+    "zh:8a34029dd7879711cddcea42bc534f585700ccb977a95cfe804555ec9c046ba0",
+    "zh:952e7bf7a23fe9e5b4131e6e5661fe6a330e35c06ca386f7bc7a16f5c12400c7",
+    "zh:bf3c6f2bbf9518655cd719e40fbe7708d379e89519e8619248394828721b6d4f",
+    "zh:ce735eab2684b3a91a97106d6d8a635daaa3a52a74d3f6352541eb4e201fc4c1",
+    "zh:cef6d47a305e679353353a305fc96f7d3f7e70e7feca8f000f69ed8a48e366b8",
+    "zh:ff9e175747fa7c3fcd3e009cf1ae40b14b8786a92e362d4426a92c5b6aca9c40",
+  ]
+}
+
+provider "registry.terraform.io/rancher/rancher2" {
+  version     = "1.17.2"
+  constraints = "1.17.2"
+  hashes = [
+    "h1:0ouGd6r51yB1GHwt/oPjisilqVRqaJTxjFWfOp46HUQ=",
+    "zh:0124345e2a901e338ed0643255c9a70ed2a5b198982accf2f5551db6d3876cd2",
+    "zh:0c8617aac79bc98601722ff52cdc0e2655ae15b25200f2dcec7b5a97aa12743c",
+    "zh:0e3524a6e0f8a7eeaeba9bb415d4b6feec379457bee2f8e1a871e9ad7b95c83c",
+    "zh:18449d2a16bf1cb968633a57ee00813ccb1105db4ba66b750bce0242ee824abc",
+    "zh:1d997446eae63b6f1645be8f12fe7e8f399ab1cc006f0813fbdf7b61e1351466",
+    "zh:52d7aade5e40c2fa372f74af36159808ea8a4f43eecd6aac1487115f9efdd74a",
+    "zh:628217fb6aa2b6c4c960b8e84b9f1d1ad7db11906295ec9ab3d77a61b63bb332",
+    "zh:7e6c632d5e183942f76a868273fa285b0dd0269c9a776382773946e2e3964999",
+    "zh:cccb2089c1c34a42373cc7076276a65378546bf0e7f33dfe15683b7db16abe51",
+    "zh:ce00e8c30a5401b8191bb256263011946f3add53704ab8471d06b5c8b8927849",
+    "zh:e391c89645c14044ce90a74ebf3bd62d6c63c5510a3bd8e63a051594848e7f16",
+    "zh:ea58c6fd2fe84280649b685715cb50ef23d16d5e344996869504b8235920685d",
+  ]
+}

--- a/hcloud/README.md
+++ b/hcloud/README.md
@@ -9,9 +9,9 @@ Both instances will be accessible over SSH using the auto-generated SSH keys `id
 - **Required**
 Hetzner Cloud API token used to create infrastructure
 
-###### `hcloud_datacenter`
-- Default: **`"fsn1-dc14"`**
-Hetzner Datacenter used for all resources
+###### `hcloud_location`
+- Default: **`"fsn1"`**
+Hetzner Location used for all resources
 
 ###### `network_zone`
 - Default: **`"eu-central"`**

--- a/hcloud/README.md
+++ b/hcloud/README.md
@@ -1,0 +1,69 @@
+# Hetzner Cloud Rancher Quickstart
+
+Two single-node RKE Kubernetes clusters will be created from two instances running Ubuntu 20.04 and Docker.
+Both instances will be accessible over SSH using the auto-generated SSH keys `id_rsa` and `id_rsa.pub`.
+
+## Variables
+
+###### `hcloud_token`
+- **Required**
+Hetzner Cloud API token used to create infrastructure
+
+###### `hcloud_datacenter`
+- Default: **`"fsn1-dc14"`**
+Hetzner Datacenter used for all resources
+
+###### `network_zone`
+- Default: **`"eu-central"`**
+Zone to create the network in
+
+###### `network_cidr`
+- Default: **`"10.0.0.0/16"`**
+Network to create for private communication
+
+###### `network_cidr`
+- Default: **`"10.0.1.0/24"`**
+Subnet to create for private communication. Must be part of the CIDR defined in `network_cidr`.
+
+###### `prefix`
+- Default: **`"quickstart"`**
+Prefix added to names of all resources
+
+###### `instance_type`
+- Default: **`"cx21"`**
+Type of instance to be used for all instances
+
+###### `docker_version`
+- Default: **`"19.03"`**
+Docker version to install on nodes
+
+###### `rancher_kubernetes_version`
+- Default: **`"v1.21.4+k3s1"`**
+Kubernetes version to use for Rancher server cluster
+
+See `rancher-common` module variable `rancher_kubernetes_version` for more details.
+
+###### `workload_kubernetes_version`
+- Default: **`"v1.20.12-rancher1-1"`**
+Kubernetes version to use for managed workload cluster
+
+See `rancher-common` module variable `workload_kubernetes_version` for more details.
+
+###### `cert_manager_version`
+- Default: **`"1.5.3"`**
+Version of cert-manager to install alongside Rancher (format: 0.0.0)
+
+See `rancher-common` module variable `cert_manager_version` for more details.
+
+###### `rancher_version`
+- Default: **`"v2.6.0"`**
+Rancher server version (format v0.0.0)
+
+See `rancher-common` module variable `rancher_version` for more details.
+
+###### `rancher_server_admin_password`
+- **Required**
+Admin password to use for Rancher server bootstrap
+
+See `rancher-common` module variable `admin_password` for more details.
+

--- a/hcloud/files/userdata_quickstart_node.template
+++ b/hcloud/files/userdata_quickstart_node.template
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+
+export DEBIAN_FRONTEND=noninteractive
+curl -sL https://releases.rancher.com/install-docker/${docker_version}.sh | sh
+sudo usermod -aG docker ${username}
+
+${register_command} --etcd --controlplane --worker

--- a/hcloud/infra.tf
+++ b/hcloud/infra.tf
@@ -1,0 +1,128 @@
+# HCloud infrastructure resources
+
+resource "tls_private_key" "global_key" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "local_file" "ssh_private_key_pem" {
+  filename          = "${path.module}/id_rsa"
+  sensitive_content = tls_private_key.global_key.private_key_pem
+  file_permission   = "0600"
+}
+
+resource "local_file" "ssh_public_key_openssh" {
+  filename = "${path.module}/id_rsa.pub"
+  content  = tls_private_key.global_key.public_key_openssh
+}
+
+resource "hcloud_network" "private" {
+  name     = "${var.prefix}-private-network"
+  ip_range = var.network_cidr
+}
+
+resource "hcloud_network_subnet" "private" {
+  type         = "cloud"
+  network_id   = hcloud_network.private.id
+  network_zone = var.network_zone
+  ip_range     = var.network_ip_range
+}
+
+# Temporary key pair used for SSH accesss
+resource "hcloud_ssh_key" "quickstart_ssh_key" {
+  name       = "${var.prefix}-instance-ssh-key"
+  public_key = tls_private_key.global_key.public_key_openssh
+}
+
+# HCloud Instance for creating a single node RKE cluster and installing the Rancher server
+resource "hcloud_server" "rancher_server" {
+  name        = "${var.prefix}-rancher-server"
+  image       = "ubuntu-20.04"
+  server_type = var.instance_type
+  location    = var.hcloud_datacenter
+  ssh_keys    = [hcloud_ssh_key.quickstart_ssh_key.id]
+
+  network {
+    network_id = hcloud_network.private.id
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.ipv4_address
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+
+  depends_on = [
+    hcloud_network_subnet.private
+  ]
+}
+
+# Rancher resources
+module "rancher_common" {
+  source = "../rancher-common"
+
+  node_public_ip             = hcloud_server.rancher_server.ipv4_address
+  node_internal_ip           = one(hcloud_server.rancher_server.network[*]).ip
+  node_username              = local.node_username
+  ssh_private_key_pem        = tls_private_key.global_key.private_key_pem
+  rancher_kubernetes_version = var.rancher_kubernetes_version
+
+  cert_manager_version = var.cert_manager_version
+  rancher_version      = var.rancher_version
+
+  rancher_server_dns = join(".", ["rancher", hcloud_server.rancher_server.ipv4_address, "sslip.io"])
+  admin_password     = var.rancher_server_admin_password
+
+  workload_kubernetes_version = var.workload_kubernetes_version
+  workload_cluster_name       = "quickstart-hcloud-custom"
+}
+
+# HCloud instance for creating a single node workload cluster
+resource "hcloud_server" "quickstart_node" {
+  name        = "${var.prefix}-worker"
+  image       = "ubuntu-20.04"
+  server_type = var.instance_type
+  location    = var.hcloud_datacenter
+  ssh_keys    = [hcloud_ssh_key.quickstart_ssh_key.id]
+
+  network {
+    network_id = hcloud_network.private.id
+  }
+
+  user_data = templatefile(
+    join("/", [path.module, "files/userdata_quickstart_node.template"]),
+    {
+      docker_version   = var.docker_version
+      username         = local.node_username
+      register_command = module.rancher_common.custom_cluster_command
+    }
+  )
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Waiting for cloud-init to complete...'",
+      "cloud-init status --wait > /dev/null",
+      "echo 'Completed cloud-init!'",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = self.ipv4_address
+      user        = local.node_username
+      private_key = tls_private_key.global_key.private_key_pem
+    }
+  }
+
+  depends_on = [
+    hcloud_network_subnet.private
+  ]
+}

--- a/hcloud/infra.tf
+++ b/hcloud/infra.tf
@@ -39,7 +39,7 @@ resource "hcloud_server" "rancher_server" {
   name        = "${var.prefix}-rancher-server"
   image       = "ubuntu-20.04"
   server_type = var.instance_type
-  location    = var.hcloud_datacenter
+  location    = var.hcloud_location
   ssh_keys    = [hcloud_ssh_key.quickstart_ssh_key.id]
 
   network {
@@ -91,7 +91,7 @@ resource "hcloud_server" "quickstart_node" {
   name        = "${var.prefix}-worker"
   image       = "ubuntu-20.04"
   server_type = var.instance_type
-  location    = var.hcloud_datacenter
+  location    = var.hcloud_location
   ssh_keys    = [hcloud_ssh_key.quickstart_ssh_key.id]
 
   network {

--- a/hcloud/output.tf
+++ b/hcloud/output.tf
@@ -1,0 +1,12 @@
+
+output "rancher_server_url" {
+  value = module.rancher_common.rancher_url
+}
+
+output "rancher_node_ip" {
+  value = hcloud_server.rancher_server.ipv4_address
+}
+
+output "workload_node_ip" {
+  value = hcloud_server.quickstart_node.ipv4_address
+}

--- a/hcloud/provider.tf
+++ b/hcloud/provider.tf
@@ -1,0 +1,6 @@
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+provider "tls" {
+}

--- a/hcloud/terraform.tfvars.example
+++ b/hcloud/terraform.tfvars.example
@@ -13,8 +13,8 @@ rancher_server_admin_password = ""
 # - Uncomment variables to customize quickstart
 # ----------------------------------------------------------
 
-# Datacenter to use for all resources
-# hcloud_datacenter = ""
+# Location to use for all resources
+# hcloud_location = ""
 
 # Prefix for all resources created by quickstart
 # prefix = ""

--- a/hcloud/terraform.tfvars.example
+++ b/hcloud/terraform.tfvars.example
@@ -1,0 +1,51 @@
+# Required variables
+# - Fill in before beginning quickstart
+# ==========================================================
+
+# Hetzner Cloud API token
+hcloud_token = ""
+
+# Password used to log in to the `admin` account on the new Rancher server
+rancher_server_admin_password = ""
+
+
+# Optional variables
+# - Uncomment variables to customize quickstart
+# ----------------------------------------------------------
+
+# Datacenter to use for all resources
+# hcloud_datacenter = ""
+
+# Prefix for all resources created by quickstart
+# prefix = ""
+
+# Type of all created instances
+# instance_type = ""
+
+# Zone to create the network in
+# network_zone = ""
+
+# Subnet to create for private communication
+# network_cidr = ""
+
+# Range to allocate IPs from.
+# - Must be a subnet of the ip_range of the Network and must not overlap with any other subnets or with any destinations in routes.
+network_ip_range     = ""
+
+# Docker version installed on target hosts
+# - Must be a version supported by the Rancher install scripts
+# docker_version = ""
+
+# Kubernetes version used for creating management server cluster
+# - Must be supported by RKE terraform provider 1.0.1
+# rancher_kubernetes_version = ""
+
+# Kubernetes version used for creating workload cluster
+# - Must be supported by RKE terraform provider 1.0.1
+# workload_kubernetes_version = ""
+
+# Version of cert-manager to install, used in case of older Rancher versions
+# cert_manager_version = ""
+
+# Version of Rancher to install
+# rancher_version = ""

--- a/hcloud/variables.tf
+++ b/hcloud/variables.tf
@@ -5,9 +5,9 @@ variable "hcloud_token" {
   description = "Hetzner Cloud API token used to create infrastructure"
 }
 
-variable "hcloud_datacenter" {
+variable "hcloud_location" {
   type        = string
-  description = "Hetzner datacenter used for all resources"
+  description = "Hetzner location used for all resources"
   default     = "fsn1"
 }
 

--- a/hcloud/variables.tf
+++ b/hcloud/variables.tf
@@ -1,0 +1,82 @@
+# Variables for Hetzner Cloud infrastructure module
+
+variable "hcloud_token" {
+  type        = string
+  description = "Hetzner Cloud API token used to create infrastructure"
+}
+
+variable "hcloud_datacenter" {
+  type        = string
+  description = "Hetzner datacenter used for all resources"
+  default     = "fsn1"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Prefix added to names of all resources"
+  default     = "quickstart"
+}
+
+variable "network_cidr" {
+  type        = string
+  description = "Network to create for private communication"
+  default     = "10.0.0.0/8"
+}
+
+variable "network_ip_range" {
+  type        = string
+  description = "Subnet to create for private communication. Must be part of the CIDR defined in `network_cidr`."
+  default     = "10.0.1.0/24"
+}
+
+variable "network_zone" {
+  type        = string
+  description = "Zone to create the network in"
+  default     = "eu-central"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Type of instance to be used for all instances"
+  default     = "cx21"
+}
+
+variable "docker_version" {
+  type        = string
+  description = "Docker version to install on nodes"
+  default     = "19.03"
+}
+
+variable "rancher_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for Rancher server cluster"
+  default     = "v1.21.4+k3s1"
+}
+
+variable "workload_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use for managed workload cluster"
+  default     = "v1.20.12-rancher1-1"
+}
+
+variable "cert_manager_version" {
+  type        = string
+  description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
+  default     = "1.5.3"
+}
+
+variable "rancher_version" {
+  type        = string
+  description = "Rancher server version (format: v0.0.0)"
+  default     = "v2.6.0"
+}
+
+variable "rancher_server_admin_password" {
+  type        = string
+  description = "Admin password to use for Rancher server bootstrap"
+}
+
+# Local variables used to reduce repetition
+locals {
+  node_username = "root"
+}

--- a/hcloud/versions.tf
+++ b/hcloud/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = ">= 1.27.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.1.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.1.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}


### PR DESCRIPTION
This PR adds quickstart information for getting started on the [Hetzner Cloud (HCloud)](https://www.hetzner.com/cloud).

* Documentation PR: https://github.com/rancher/docs/pull/3701

This code has been tested against our own Hetzner account and resulted in 2 clusters and a working Rancher frontend.