### PR TITLE
added ip range to support latest virtual box on mac.

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -13,7 +13,7 @@ This folder contains Vagrant code to stand up a single Rancher server instance w
 0. Clone this repository and go into the vagrant subfolder
 0. Run `vagrant up`
 
-When provisioning is finished the Rancher UI will become accessible on [172.22.101.101](http://172.22.101.101).
+When provisioning is finished the Rancher UI will become accessible on [192.168.56.101](http://192.168.56.101).
 The default password is `admin`, but this can be updated in the config.yaml file.
 
 If you want to keep the configuration changes outside the git repository you can copy the config.yaml file to local_config.yaml and make changes there.

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -8,12 +8,12 @@ server:
   memory: 1500
 node:
   count: 1
-  cpus: 1
-  memory: 1500
+  cpus: 2
+  memory: 2400
 ip:
-  master: 172.22.101.100
-  server: 172.22.101.101
-  node:   172.22.101.111
+  master: 192.168.56.100
+  server: 192.168.56.101
+  node:   192.168.56.111
 linked_clones: true
 net:
   private_nic_type: 82545EM

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -8,8 +8,8 @@ server:
   memory: 1500
 node:
   count: 1
-  cpus: 2
-  memory: 2400
+  cpus: 1
+  memory: 1500
 ip:
   master: 192.168.56.100
   server: 192.168.56.101

--- a/vagrant/scripts/configure_rancher_node.sh
+++ b/vagrant/scripts/configure_rancher_node.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
-rancher_server_ip=${1:-172.22.101.101}
+rancher_server_ip=${1:-192.168.56.101}
 admin_password=${2:-password}
 curlimage="appropriate/curl"
 jqimage="stedolan/jq"

--- a/vagrant/scripts/configure_rancher_server.sh
+++ b/vagrant/scripts/configure_rancher_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-rancher_ip="172.22.101.101"
+rancher_ip="192.168.56.101"
 admin_password=${1:-password}
 rancher_version=${2:-stable}
 k8s_version=$3


### PR DESCRIPTION
Per #187 VirtualBox >= 6.1.28 and Vagrant >= 2.2.19 require an IP range of 192.168.56.0/21. https://discuss.hashicorp.com/t/vagrant-2-2-18-osx-11-6-cannot-create-private-network/30984/4 

This PR addresses this issue by simply swapping the IPs. 