### PR TITLE
vagrant: set default password to "adminPassword"

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -14,7 +14,7 @@ This folder contains Vagrant code to stand up a single Rancher server instance w
 0. Run `vagrant up`
 
 When provisioning is finished the Rancher UI will become accessible on [192.168.56.101](http://192.168.56.101).
-The default password is `admin`, but this can be updated in the config.yaml file.
+The default password is `adminPassword`, but this can be updated in the config.yaml file (must be at least 12 characters).
 
 If you want to keep the configuration changes outside the git repository you can copy the config.yaml file to local_config.yaml and make changes there.
 

--- a/vagrant/config.yaml
+++ b/vagrant/config.yaml
@@ -1,4 +1,4 @@
-admin_password: admin
+admin_password: adminPassword
 rancher_version: v2.6.3
 ROS_version: 1.5.1
 # Empty defaults to latest non-experimental available


### PR DESCRIPTION
In the Vagrant quickstart, the default admin password (`admin_password: admin`) no longer works because it's less than 12 characters. This error is unhandled, causing the rest of the provisioning process to be incomplete. The provisioning script keeps running, so the error message is buried under a lot of additional output.

This PR changes the default admin password to `adminPassword`, which allows provisioning to succeed. If this is accepted, I have a [docs branch](https://github.com/thinkmassive/rancher-docs/commit/8a3cd9e0ccf39ab3bd2646bf0997b8656359dd7f) ready to update that repo as well.