### PR TITLE
Add option open-iscsi to support longhorn

### DIFF
--- a/rancher/vagrant/README.md
+++ b/rancher/vagrant/README.md
@@ -16,6 +16,8 @@ This folder contains Vagrant code to stand up a single Rancher server instance w
 When provisioning is finished the Rancher UI will become accessible on [192.168.56.101](http://192.168.56.101).
 The default password is `adminPassword`, but this can be updated in the config.yaml file (must be at least 12 characters).
 
+If you want to enable open-iscsi (to enable longhorn) you can set `node.open-iscsi: enabled` in config.yaml or local_config.yaml.
+
 If you want to keep the configuration changes outside the git repository you can copy the config.yaml file to local_config.yaml and make changes there.
 
 ## Remove

--- a/rancher/vagrant/Vagrantfile
+++ b/rancher/vagrant/Vagrantfile
@@ -12,6 +12,11 @@ else
 end
 puts "Config: #{x.inspect}\n\n"
 
+if !x["node"].nil? && x["node"]["open-iscsi"].nil? || x["node"]["open-iscsi"].empty? then
+  x["node"]["open-iscsi"] = "disabled"
+  puts "open-iscsi not set (default is disabled)"
+end
+
 $private_nic_type = x.fetch('net').fetch('private_nic_type')
 
 Vagrant.configure(2) do |config|
@@ -53,7 +58,7 @@ Vagrant.configure(2) do |config|
       end
       node.vm.network x.fetch('net').fetch('network_type'), ip: IPAddr.new(node_ip.to_i + i - 1, Socket::AF_INET).to_s, nic_type: $private_nic_type
       node.vm.hostname = hostname
-      node.vm.provision "shell", path: "scripts/configure_rancher_node.sh", args: [x.fetch('ip').fetch('server'), x.fetch('admin_password')]
+      node.vm.provision "shell", path: "scripts/configure_rancher_node.sh", args: [x.fetch('ip').fetch('server'), x.fetch('admin_password'), x.fetch("node").fetch("open-iscsi")]
     end
   end
 

--- a/rancher/vagrant/config.yaml
+++ b/rancher/vagrant/config.yaml
@@ -10,6 +10,7 @@ node:
   count: 1
   cpus: 1
   memory: 1500
+  open-iscsi: disabled
 ip:
   master: 192.168.56.100
   server: 192.168.56.101

--- a/rancher/vagrant/scripts/configure_rancher_node.sh
+++ b/rancher/vagrant/scripts/configure_rancher_node.sh
@@ -3,6 +3,7 @@ rancher_server_ip=${1:-192.168.56.101}
 admin_password=${2:-password}
 curlimage="appropriate/curl"
 jqimage="stedolan/jq"
+enabled_iscsi=${3:-"disabled"}
 
 agent_ip=`ip addr show eth1 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1`
 echo $agent_ip `hostname` >> /etc/hosts
@@ -78,3 +79,13 @@ done
 # Show the command
 COMPLETECMD="$AGENTCMD $ROLEFLAGS --internal-address $agent_ip --address $agent_ip "
 $COMPLETECMD
+
+if [ "$enabled_iscsi" = "enabled" ] ; then
+# Enable iscsi, stat and flock
+  sudo wget https://busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox_STAT -O /bin/stat
+  sudo wget https://busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox_FLOCK -O /bin/flock
+  sudo chmod +x /bin/stat
+  sudo chmod +x /bin/flock
+  sudo ros s enable open-iscsi
+  sudo ros s up open-iscsi
+fi


### PR DESCRIPTION
With Rancher-OS by default longhon doesn't work because on this distro we haven't open-iscsi enabled by default and longhonr manager require 2 binary stat and flock