### PR TITLE
fix: windows ami does not exist

### DIFF
--- a/rancher/aws/data.tf
+++ b/rancher/aws/data.tf
@@ -34,7 +34,7 @@ data "aws_ami" "windows" {
   owners      = ["801119661308"] #Amazon
   filter {
     name   = "name"
-    values = ["Windows_Server-2019-English-Full-ContainersLatest-*"]
+    values = ["Windows_Server-2019-English-Full-Base*"]
   }
 
   filter {


### PR DESCRIPTION
Resolves #224 

Following the [AWS quickstart instructions](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/aws) results in the following Terraform error:
```
│ Error: Your query returned no results. Please change your search criteria and try again.
│ 
│   with data.aws_ami.windows,
│   on data.tf line 32, in data "aws_ami" "windows":
│   32: data "aws_ami" "windows" {
│ 
```

This AMI no longer exists. When the fix in this PR is applied, it matches `ami-06404b83fffc8f0ca` in my `eu-west-3` region, and resolves to `Windows_Server-2019-English-Full-SQL_2019_Web-2024.06.13`.