### PR TITLE
fix(rancher-common): Helm error, could not download chart

### DIFF
--- a/rancher/rancher-common/provider.tf
+++ b/rancher/rancher-common/provider.tf
@@ -24,6 +24,8 @@ provider "helm" {
   kubernetes {
     config_path = local_file.kube_config_server_yaml.filename
   }
+  repository_config_path = "${path.module}/.helm/repositories.yaml"
+  repository_cache       = "${path.module}/.helm"
 }
 
 # Rancher2 bootstrapping provider


### PR DESCRIPTION
Workaround for:

`Error: could not download chart: no cached repo found. (try 'helm repo update')`

Refs: https://github.com/hashicorp/terraform-provider-helm/issues/630