### PR TITLE
feat(rancher/aws): Use AWS env vars, use null defaults

### DIFF
--- a/rancher/aws/terraform.tfvars.example
+++ b/rancher/aws/terraform.tfvars.example
@@ -1,45 +1,45 @@
 
 # AWS access key used to create infrastructure
-aws_access_key = ""
+#aws_access_key = ""
 
 # AWS secret key used to create AWS infrastructure
-aws_secret_key = ""
+#aws_secret_key = ""
 
 # Admin password to use for Rancher server bootstrap, min. 12 characters
 rancher_server_admin_password = ""
 
 # Add a windows node to the workload cluster
-add_windows_node = false
+#add_windows_node = false
 
 # AWS region used for all resources
-aws_region = "us-east-1"
+#aws_region = "us-east-1"
 
 # AWS session token used to create AWS infrastructure
-aws_session_token = ""
+#aws_session_token = ""
 
 # AWS zone used for all resources
-aws_zone = "us-east-1b"
+#aws_zone = ""
 
 # Version of cert-manager to install alongside Rancher (format: 0.0.0)
-cert_manager_version = "1.11.0"
+#cert_manager_version = "1.11.0"
 
 # Instance type used for all EC2 instances
-instance_type = "t3a.medium"
+#instance_type = "t3a.medium"
 
 # Prefix added to names of all resources
-prefix = "quickstart"
+#prefix = "quickstart"
 
 # The helm repository, where the Rancher helm chart is installed from
-rancher_helm_repository = "https://releases.rancher.com/server-charts/latest"
+#rancher_helm_repository = "https://releases.rancher.com/server-charts/latest"
 
 # Kubernetes version to use for Rancher server cluster
-rancher_kubernetes_version = "v1.24.14+k3s1"
+#rancher_kubernetes_version = "v1.24.14+k3s1"
 
 # Rancher server version (format: v0.0.0)
-rancher_version = "2.7.9"
+#rancher_version = "2.7.9"
 
 # Instance type used for all EC2 windows instances
-windows_instance_type = "t3a.large"
+#windows_instance_type = "t3a.large"
 
 # Kubernetes version to use for managed workload cluster
-workload_kubernetes_version = "v1.24.14+rke2r1"
+#workload_kubernetes_version = "v1.24.14+rke2r1"

--- a/rancher/aws/variables.tf
+++ b/rancher/aws/variables.tf
@@ -1,17 +1,15 @@
 # Variables for AWS infrastructure module
 
-// TODO - use null defaults
-
-# Required
 variable "aws_access_key" {
   type        = string
   description = "AWS access key used to create infrastructure"
+  default     = ""
 }
 
-# Required
 variable "aws_secret_key" {
   type        = string
   description = "AWS secret key used to create AWS infrastructure"
+  default     = ""
 }
 
 variable "aws_session_token" {
@@ -29,7 +27,7 @@ variable "aws_region" {
 variable "aws_zone" {
   type        = string
   description = "AWS zone used for all resources"
-  default     = "us-east-1b"
+  default     = ""
 }
 
 variable "prefix" {
@@ -86,7 +84,6 @@ variable "rancher_server_admin_password" {
   description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
 }
 
-# Required
 variable "add_windows_node" {
   type        = bool
   description = "Add a windows node to the workload cluster"


### PR DESCRIPTION
By using null defaults for AWS credentials, the Provider will use Env vars that are set and automatically leverage temporary credentials as well. A user can always decide to set the values like before. But by default it will 'just work' if there are already environment variables set.

The availability zone now also defaults to null, which leaves the decision which one to deploy the resources into up to the Provider. If the variable is set, the behavior is like before.