### PR TITLE
feat(rancher/aws): Bump rancher, rke2, k3s, cert-manager version

### DIFF
--- a/rancher/aws/terraform.tfvars.example
+++ b/rancher/aws/terraform.tfvars.example
@@ -9,37 +9,37 @@ aws_secret_key = ""
 rancher_server_admin_password = ""
 
 # Add a windows node to the workload cluster
-add_windows_node = false
+#add_windows_node = false
 
 # AWS region used for all resources
-aws_region = "us-east-1"
+#aws_region = "us-east-1"
 
 # AWS session token used to create AWS infrastructure
-aws_session_token = ""
+#aws_session_token = ""
 
 # AWS zone used for all resources
-aws_zone = "us-east-1b"
+#aws_zone = "us-east-1b"
 
 # Version of cert-manager to install alongside Rancher (format: 0.0.0)
-cert_manager_version = "1.11.0"
+#cert_manager_version = "1.16.0"
 
 # Instance type used for all EC2 instances
-instance_type = "t3a.medium"
+#instance_type = "t3a.medium"
 
 # Prefix added to names of all resources
-prefix = "quickstart"
+#prefix = "quickstart"
 
 # The helm repository, where the Rancher helm chart is installed from
-rancher_helm_repository = "https://releases.rancher.com/server-charts/latest"
+#rancher_helm_repository = "https://releases.rancher.com/server-charts/latest"
 
 # Kubernetes version to use for Rancher server cluster
-rancher_kubernetes_version = "v1.24.14+k3s1"
+#rancher_kubernetes_version = "v1.30.4+k3s1"
 
 # Rancher server version (format: v0.0.0)
-rancher_version = "2.7.9"
+#rancher_version = "2.9.2"
 
 # Instance type used for all EC2 windows instances
-windows_instance_type = "t3a.large"
+#windows_instance_type = "t3a.large"
 
 # Kubernetes version to use for managed workload cluster
-workload_kubernetes_version = "v1.24.14+rke2r1"
+#workload_kubernetes_version = "v1.30.4+rke2r1"

--- a/rancher/aws/variables.tf
+++ b/rancher/aws/variables.tf
@@ -53,25 +53,25 @@ variable "windows_instance_type" {
 variable "rancher_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for Rancher server cluster"
-  default     = "v1.24.14+k3s1"
+  default     = "v1.30.4+k3s1"
 }
 
 variable "workload_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for managed workload cluster"
-  default     = "v1.24.14+rke2r1"
+  default     = "v1.30.4+rke2r1"
 }
 
 variable "cert_manager_version" {
   type        = string
   description = "Version of cert-manager to install alongside Rancher (format: 0.0.0)"
-  default     = "1.11.0"
+  default     = "1.16.0"
 }
 
 variable "rancher_version" {
   type        = string
   description = "Rancher server version (format: v0.0.0)"
-  default     = "2.7.9"
+  default     = "2.9.2"
 }
 
 variable "rancher_helm_repository" {
@@ -86,7 +86,6 @@ variable "rancher_server_admin_password" {
   description = "Admin password to use for Rancher server bootstrap, min. 12 characters"
 }
 
-# Required
 variable "add_windows_node" {
   type        = bool
   description = "Add a windows node to the workload cluster"


### PR DESCRIPTION
Also, comment out all values with defaults in 'terraform.tfvars.example'. No need to set them again, if someone wants to customize they can just uncomment and provide the desired value.

Tested with OpenTofu:
```
OpenTofu v1.8.2
on darwin_arm64
+ provider registry.opentofu.org/hashicorp/aws v5.1.0
+ provider registry.opentofu.org/hashicorp/helm v2.10.1
+ provider registry.opentofu.org/hashicorp/local v2.4.0
+ provider registry.opentofu.org/hashicorp/tls v4.0.4
+ provider registry.opentofu.org/loafoe/ssh v2.6.0
+ provider registry.opentofu.org/rancher/rancher2 v3.0.0
```