### PR TITLE
feat(rancher): Use latest SLES 15 SP6 PAYG AMI

### DIFF
--- a/rancher/aws/data.tf
+++ b/rancher/aws/data.tf
@@ -3,14 +3,14 @@
 # AWS data
 # ----------------------------------------------------------
 
-# Use latest SLES 15 SP3
+# Use latest SLES 15 SP6 PAYG AMI
 data "aws_ami" "sles" {
   most_recent = true
   owners      = ["013907871322"] # SUSE
 
   filter {
     name   = "name"
-    values = ["suse-sles-15-sp3*"]
+    values = ["suse-sles-15-sp6-v*"]
   }
 
   filter {


### PR DESCRIPTION
Currently SLES 15 SP3 BYOS is used.
It's out of support and bring-your-own-subscription requires manual registration. 

This PR performs a version bump to SLES 15 SP6 and switches to a PAYG AMI. 
I want access to repos to install updates or additional packages in my Rancher test / demo environment out-of-the-box.