### PR TITLE
feat(rancher): AWS - Switch Rancher Server public ip to EIP

### DIFF
--- a/rancher/aws/infra.tf
+++ b/rancher/aws/infra.tf
@@ -92,6 +92,13 @@ resource "aws_security_group" "rancher_sg_allowall" {
   }
 }
 
+# EIP resource for Rancher Server
+resource "aws_eip" "rancher_server" {
+  domain   = "vpc"
+
+  depends_on = [aws_internet_gateway.rancher_gateway]
+}
+
 # AWS EC2 instance for creating a single node RKE cluster and installing the Rancher server
 resource "aws_instance" "rancher_server" {
   depends_on = [
@@ -130,11 +137,17 @@ resource "aws_instance" "rancher_server" {
   }
 }
 
+# EIP explicit allocation for Rancher Server
+resource "aws_eip_association" "rancher_server" {
+  instance_id   = aws_instance.rancher_server.id
+  allocation_id = aws_eip.rancher_server.id
+}
+
 # Rancher resources
 module "rancher_common" {
   source = "../rancher-common"
 
-  node_public_ip             = aws_instance.rancher_server.public_ip
+  node_public_ip             = aws_eip_association.rancher_server.public_ip
   node_internal_ip           = aws_instance.rancher_server.private_ip
   node_username              = local.node_username
   ssh_private_key_pem        = tls_private_key.global_key.private_key_pem
@@ -144,7 +157,7 @@ module "rancher_common" {
   rancher_version         = var.rancher_version
   rancher_helm_repository = var.rancher_helm_repository
 
-  rancher_server_dns = join(".", ["rancher", aws_instance.rancher_server.public_ip, "sslip.io"])
+  rancher_server_dns = join(".", ["rancher", aws_eip_association.rancher_server.public_ip, "sslip.io"])
 
   admin_password = var.rancher_server_admin_password
 

--- a/rancher/aws/output.tf
+++ b/rancher/aws/output.tf
@@ -3,7 +3,7 @@ output "rancher_server_url" {
 }
 
 output "rancher_node_ip" {
-  value = aws_instance.rancher_server.public_ip
+  value = aws_eip.rancher_server.public_ip
 }
 
 output "workload_node_ip" {


### PR DESCRIPTION
AWS - Switch Rancher Server public ip to EIP. This keeps the public ip static.

Changes to the instance, e.g. shutdown/start, will not cause an assignment of a new public IP address anymore.

Solves issues were destroy failed at 'rancher2_bootstrap' and 'rancher2_cluster_v2' because the public ip was already removed.

Fixes: https://github.com/rancher/quickstart/issues/223

Fixes: https://github.com/rancher/quickstart/issues/242

Apply and destroy order after the proposed changes:

apply
```
tls_private_key.global_key: Creating...
tls_private_key.global_key: Creation complete after 0s [id=72e2d3fc1f40a6d38dfda5259b4139980ff2f90f]
local_sensitive_file.ssh_private_key_pem: Creating...
local_file.ssh_public_key_openssh: Creating...
local_file.ssh_public_key_openssh: Creation complete after 0s [id=a09bd8ce0d3d944fca38fe4c9e5c1b5dc709de5d]
local_sensitive_file.ssh_private_key_pem: Creation complete after 0s [id=8967dbf1d2cb6e918e31ac1b36abe5edb903fe32]
aws_key_pair.quickstart_key_pair: Creating...
aws_vpc.rancher_vpc: Creating...
aws_key_pair.quickstart_key_pair: Creation complete after 1s [id=quickstart-rancher-20241104144907282300000001]
aws_vpc.rancher_vpc: Still creating... [10s elapsed]
aws_vpc.rancher_vpc: Creation complete after 12s [id=vpc-08aedb06623d67b6d]
aws_internet_gateway.rancher_gateway: Creating...
aws_subnet.rancher_subnet: Creating...
aws_security_group.rancher_sg_allowall: Creating...
aws_internet_gateway.rancher_gateway: Creation complete after 0s [id=igw-06024e5945500b9f2]
aws_eip.rancher_server: Creating...
aws_route_table.rancher_route_table: Creating...
aws_subnet.rancher_subnet: Creation complete after 1s [id=subnet-0ce769c164b37371e]
aws_eip.rancher_server: Creation complete after 1s [id=eipalloc-06eac4807a4de30d6]
aws_route_table.rancher_route_table: Creation complete after 1s [id=rtb-08c36a406693dc7ad]
aws_route_table_association.rancher_route_table_association: Creating...
aws_route_table_association.rancher_route_table_association: Creation complete after 0s [id=rtbassoc-04dca5b7eacf99c6e]
aws_security_group.rancher_sg_allowall: Creation complete after 2s [id=sg-0c46f58eed5c596c6]
aws_instance.rancher_server: Creating...
aws_instance.rancher_server: Still creating... [10s elapsed]
aws_instance.rancher_server: Provisioning with 'remote-exec'...
aws_instance.rancher_server (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.rancher_server: Still creating... [20s elapsed]
aws_instance.rancher_server (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.rancher_server: Still creating... [30s elapsed]
aws_instance.rancher_server: Still creating... [40s elapsed]
aws_instance.rancher_server (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.rancher_server (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.rancher_server: Still creating... [50s elapsed]
[...]
aws_instance.rancher_server: Still creating... [1m0s elapsed]
[...]
aws_instance.rancher_server: Still creating... [1m10s elapsed]
aws_instance.rancher_server (remote-exec): Connected!
aws_instance.rancher_server (remote-exec): Waiting for cloud-init to complete...
aws_instance.rancher_server: Still creating... [1m20s elapsed]
aws_instance.rancher_server (remote-exec): Completed cloud-init!
aws_instance.rancher_server: Creation complete after 1m28s [id=i-0e8da7f46d32fb278]
aws_eip_association.rancher_server: Creating...
aws_eip_association.rancher_server: Creation complete after 1s [id=eipassoc-05265554d07e78d75]
module.rancher_common.ssh_resource.install_k3s: Creating...
module.rancher_common.ssh_resource.install_k3s: Still creating... [10s elapsed]
module.rancher_common.ssh_resource.install_k3s: Creation complete after 16s [id=8008997445186176696]
module.rancher_common.ssh_resource.retrieve_config: Creating...
module.rancher_common.ssh_resource.retrieve_config: Creation complete after 0s [id=3607091416596735199]
module.rancher_common.local_file.kube_config_server_yaml: Creating...
module.rancher_common.local_file.kube_config_server_yaml: Creation complete after 0s [id=f057b61e0b7f0dea87852dcf57babdd52c21d6be]
module.rancher_common.helm_release.cert_manager: Creating...
module.rancher_common.helm_release.cert_manager: Still creating... [10s elapsed]
[...]
module.rancher_common.helm_release.cert_manager: Still creating... [40s elapsed]
module.rancher_common.helm_release.cert_manager: Creation complete after 45s [id=cert-manager]
module.rancher_common.helm_release.rancher_server: Creating...
module.rancher_common.helm_release.rancher_server: Still creating... [10s elapsed]
[...]
module.rancher_common.helm_release.rancher_server: Still creating... [1m40s elapsed]
module.rancher_common.helm_release.rancher_server: Creation complete after 1m46s [id=rancher]
module.rancher_common.rancher2_bootstrap.admin: Creating...
module.rancher_common.rancher2_bootstrap.admin: Still creating... [10s elapsed]
module.rancher_common.rancher2_bootstrap.admin: Creation complete after 13s [id=user-jrg5j]
module.rancher_common.rancher2_cluster_v2.quickstart_workload: Creating...
module.rancher_common.rancher2_cluster_v2.quickstart_workload: Creation complete after 7s [id=fleet-default/quickstart-aws-custom]
module.rancher_common.local_file.kube_config_workload_yaml: Creating...
module.rancher_common.local_file.kube_config_workload_yaml: Creation complete after 0s [id=8721b3b80f67522ae03a5fc46ea5cfe66ce45baa]
aws_instance.quickstart_node: Creating...
aws_instance.quickstart_node: Still creating... [10s elapsed]
aws_instance.quickstart_node: Provisioning with 'remote-exec'...
aws_instance.quickstart_node (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.quickstart_node: Still creating... [20s elapsed]
aws_instance.quickstart_node (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.quickstart_node: Still creating... [30s elapsed]
aws_instance.quickstart_node: Still creating... [40s elapsed]
aws_instance.quickstart_node (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.quickstart_node (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.quickstart_node: Still creating... [50s elapsed]
aws_instance.quickstart_node (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.quickstart_node: Still creating... [1m0s elapsed]
aws_instance.quickstart_node (remote-exec): Connecting to remote host via SSH...
[...]
aws_instance.quickstart_node: Still creating... [1m10s elapsed]
aws_instance.quickstart_node (remote-exec): Connected!
aws_instance.quickstart_node (remote-exec): Waiting for cloud-init to complete...
aws_instance.quickstart_node: Still creating... [1m20s elapsed]
[...]
aws_instance.quickstart_node: Still creating... [2m30s elapsed]
aws_instance.quickstart_node (remote-exec): Completed cloud-init!
aws_instance.quickstart_node: Creation complete after 2m34s [id=i-0067f4be02e9d22c0]

Apply complete! Resources: 22 added, 0 changed, 0 destroyed.
```

destroy
```
local_file.ssh_public_key_openssh: Destroying... [id=a09bd8ce0d3d944fca38fe4c9e5c1b5dc709de5d]
local_sensitive_file.ssh_private_key_pem: Destroying... [id=8967dbf1d2cb6e918e31ac1b36abe5edb903fe32]
module.rancher_common.local_file.kube_config_workload_yaml: Destroying... [id=8721b3b80f67522ae03a5fc46ea5cfe66ce45baa]
local_file.ssh_public_key_openssh: Destruction complete after 0s
module.rancher_common.local_file.kube_config_workload_yaml: Destruction complete after 0s
local_sensitive_file.ssh_private_key_pem: Destruction complete after 0s
aws_instance.quickstart_node: Destroying... [id=i-0067f4be02e9d22c0]
aws_instance.quickstart_node: Still destroying... [id=i-0067f4be02e9d22c0, 10s elapsed]
[...]
aws_instance.quickstart_node: Still destroying... [id=i-0067f4be02e9d22c0, 2m30s elapsed]
aws_instance.quickstart_node: Destruction complete after 2m32s
module.rancher_common.rancher2_cluster_v2.quickstart_workload: Destroying... [id=fleet-default/quickstart-aws-custom]
module.rancher_common.rancher2_cluster_v2.quickstart_workload: Destruction complete after 4s
module.rancher_common.rancher2_bootstrap.admin: Destroying... [id=user-jrg5j]
module.rancher_common.rancher2_bootstrap.admin: Destruction complete after 0s
module.rancher_common.helm_release.rancher_server: Destroying... [id=rancher]
module.rancher_common.helm_release.rancher_server: Still destroying... [id=rancher, 10s elapsed]
module.rancher_common.helm_release.rancher_server: Destruction complete after 16s
module.rancher_common.helm_release.cert_manager: Destroying... [id=cert-manager]
module.rancher_common.helm_release.cert_manager: Still destroying... [id=cert-manager, 10s elapsed]
[...]
module.rancher_common.local_file.kube_config_server_yaml: Destroying... [id=f057b61e0b7f0dea87852dcf57babdd52c21d6be]
module.rancher_common.local_file.kube_config_server_yaml: Destruction complete after 0s
module.rancher_common.ssh_resource.retrieve_config: Destroying... [id=3607091416596735199]
module.rancher_common.ssh_resource.retrieve_config: Destruction complete after 0s
module.rancher_common.ssh_resource.install_k3s: Destroying... [id=8008997445186176696]
module.rancher_common.ssh_resource.install_k3s: Destruction complete after 0s
aws_eip_association.rancher_server: Destroying... [id=eipassoc-05265554d07e78d75]
aws_eip_association.rancher_server: Destruction complete after 1s
aws_eip.rancher_server: Destroying... [id=eipalloc-06eac4807a4de30d6]
aws_instance.rancher_server: Destroying... [id=i-0e8da7f46d32fb278]
aws_eip.rancher_server: Destruction complete after 1s
aws_instance.rancher_server: Still destroying... [id=i-0e8da7f46d32fb278, 10s elapsed]
[...]
aws_instance.rancher_server: Still destroying... [id=i-0e8da7f46d32fb278, 2m20s elapsed]
aws_instance.rancher_server: Destruction complete after 2m22s
aws_route_table_association.rancher_route_table_association: Destroying... [id=rtbassoc-04dca5b7eacf99c6e]
aws_key_pair.quickstart_key_pair: Destroying... [id=quickstart-rancher-20241104144907282300000001]
aws_security_group.rancher_sg_allowall: Destroying... [id=sg-0c46f58eed5c596c6]
aws_route_table_association.rancher_route_table_association: Destruction complete after 0s
aws_subnet.rancher_subnet: Destroying... [id=subnet-0ce769c164b37371e]
aws_route_table.rancher_route_table: Destroying... [id=rtb-08c36a406693dc7ad]
aws_key_pair.quickstart_key_pair: Destruction complete after 0s
tls_private_key.global_key: Destroying... [id=72e2d3fc1f40a6d38dfda5259b4139980ff2f90f]
tls_private_key.global_key: Destruction complete after 0s
aws_subnet.rancher_subnet: Destruction complete after 1s
aws_security_group.rancher_sg_allowall: Destruction complete after 1s
aws_route_table.rancher_route_table: Destruction complete after 1s
aws_internet_gateway.rancher_gateway: Destroying... [id=igw-06024e5945500b9f2]
aws_internet_gateway.rancher_gateway: Destruction complete after 0s
aws_vpc.rancher_vpc: Destroying... [id=vpc-08aedb06623d67b6d]
aws_vpc.rancher_vpc: Destruction complete after 1s

Destroy complete! Resources: 22 destroyed.
```
