### PR TITLE
fix(rancher): AWS - destroy helm_release.cert_manager timeout

### DIFF
--- a/rancher/rancher-common/helm.tf
+++ b/rancher/rancher-common/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "cert_manager" {
   chart            = "https://charts.jetstack.io/charts/cert-manager-v${var.cert_manager_version}.tgz"
   namespace        = "cert-manager"
   create_namespace = true
-  wait             = true
+  wait             = false
 
   set {
     name  = "installCRDs"


### PR DESCRIPTION
Resource 'module.rancher_common.helm_release.cert_manager' runs into 5m timeout during destroy with cert-manager >=1.15.0 because of CRD resource policy. Running Helm without `wait`, uninstall works. More details in related Issue https://github.com/rancher/quickstart/issues/244.

Refs: https://github.com/rancher/quickstart/pull/240

Fixes: https://github.com/rancher/quickstart/issues/244